### PR TITLE
Handle nested case conversions

### DIFF
--- a/src/utils/caseConversions.js
+++ b/src/utils/caseConversions.js
@@ -38,6 +38,8 @@ export const convertSnakeToCamel = str => {
  * @param {function} transformer Function dictating how the keys should be transformed.
  */
 export const translateObjectKeys = (obj, transformer) => {
+
+  // if object is array we need to recursively translate all values in the array only if they are an object or an array
   if(Array.isArray(obj)) {
     return obj.map(v => typeof v === 'object' && v !== null ? translateObjectKeys(v, transformer) : v);
   }
@@ -46,8 +48,9 @@ export const translateObjectKeys = (obj, transformer) => {
 
   for(const [ key, value ] of Object.entries(obj)) {
     const transformedKey = transformer(key);
-    let transformedValue = value; // if value is array or object we need to recursively translate its keys as well
+    let transformedValue = value; 
 
+    // if value is array or object we need to recursively translate its keys as well
     if(typeof value === 'object' && value !== null) {
       transformedValue = translateObjectKeys(value, transformer);
     }

--- a/src/utils/caseConversions.js
+++ b/src/utils/caseConversions.js
@@ -1,3 +1,7 @@
+/**
+ * Given a string assumed to be in camelCase, return the given string transformed into snake_case.
+ * @param {string} str The string to transform.
+ */
 export const convertCamelToSnake = str => {
   let output = '';
   for(const char of str.split('')) {
@@ -7,6 +11,10 @@ export const convertCamelToSnake = str => {
   return output;
 };
 
+/**
+ * Given a string assumed to be in snake_case, return the given string transformed into camelCase.
+ * @param {string} str The string to transform.
+ */
 export const convertSnakeToCamel = str => {
   let output = '';
   let upperCaseFlag = false;
@@ -22,13 +30,30 @@ export const convertSnakeToCamel = str => {
   return output;
 };
 
-// TODO: make this work with nested objects
+/**
+ * Given an object and a function to transform key names in the object, create and return a new object such that:
+ *  - For any key S in the original object, the same value is present in the returned object at key transformer(S).
+ *  - For any nested array or object in the given object, the same logic is applied.
+ * @param {object or array} obj The object to transform keys for.
+ * @param {function} transformer Function dictating how the keys should be transformed.
+ */
 export const translateObjectKeys = (obj, transformer) => {
-  const resultingObj = {};
+  if(Array.isArray(obj)) {
+    return obj.map(v => typeof v === 'object' && v !== null ? translateObjectKeys(v, transformer) : v);
+  }
+
+  const transformedObj = {};
 
   for(const [ key, value ] of Object.entries(obj)) {
-    resultingObj[transformer(key)] = value;
+    const transformedKey = transformer(key);
+    let transformedValue = value; // if value is array or object we need to recursively translate its keys as well
+
+    if(typeof value === 'object' && value !== null) {
+      transformedValue = translateObjectKeys(value, transformer);
+    }
+
+    transformedObj[transformedKey] = transformedValue;
   };
 
-  return resultingObj;
+  return transformedObj;
 };

--- a/src/utils/caseConversions.test.js
+++ b/src/utils/caseConversions.test.js
@@ -20,8 +20,8 @@ describe('converting snake to camel', () => {
   });
 });
 
-describe('converting object keys to snake', () => {
-  test('should convert object keys to snake case', () => {
+describe('converting object keys', () => {
+  test('should convert object keys from camel case to snake case', () => {
     const obj = { firstName: 'jacob', lastName: 'eckert', password: 'test' };
 
     const translatedObj = translateObjectKeys(obj, convertCamelToSnake);
@@ -31,5 +31,122 @@ describe('converting object keys to snake', () => {
     expect(translatedObj).not.toHaveProperty('lastName');
     expect(translatedObj).toHaveProperty('last_name');
     expect(translatedObj).toHaveProperty('password');
+
+    expect(translatedObj.first_name).toEqual('jacob');
+    expect(translatedObj.last_name).toEqual('eckert');
+    expect(translatedObj.password).toEqual('test');
+  });
+
+  test('should convert object keys from snake case to camel case', () => {
+    const obj = { first_name: 'jacob', last_name: 'eckert', password: 'test' };
+
+    const translatedObj = translateObjectKeys(obj, convertSnakeToCamel);
+
+    expect(translatedObj).not.toHaveProperty('first_name');
+    expect(translatedObj).toHaveProperty('firstName');
+    expect(translatedObj).not.toHaveProperty('last_name');
+    expect(translatedObj).toHaveProperty('lastName');
+    expect(translatedObj).toHaveProperty('password');
+
+    expect(translatedObj.firstName).toEqual('jacob');
+    expect(translatedObj.lastName).toEqual('eckert');
+    expect(translatedObj.password).toEqual('test');
+  });
+
+  test('should properly convert keys in nested objects or arrays', () => {
+    const obj = {
+      id: 1,
+      null: null,
+      userInfo: {
+        firstName: 'jacob',
+        lastName: 'eckert',
+        password: 'test'
+      },
+      favoriteColors: [ 'red', 'green', 'blue' ],
+      favoriteSongs: [
+        { songName: 'Save a Secret for the Moon', artistName: 'The Magnetic Fields' },
+        { songName: 'Baby', artistName: 'of Montreal'}
+      ]
+    };
+
+    const translatedObj = translateObjectKeys(obj, convertCamelToSnake);
+
+    // check top level
+    expect(translatedObj).toHaveProperty('id');
+    expect(translatedObj).toHaveProperty('null');
+    expect(translatedObj).toHaveProperty('user_info');
+    expect(translatedObj).toHaveProperty('favorite_colors');
+    expect(translatedObj).toHaveProperty('favorite_songs');
+    expect(translatedObj).not.toHaveProperty('userInfo');
+    expect(translatedObj).not.toHaveProperty('favoriteColors');
+    expect(translatedObj).not.toHaveProperty('favoriteSongs');
+    expect(translatedObj.id).toEqual(1);
+    expect(translatedObj.null).toEqual(null);
+
+    // check nested object
+    expect(translatedObj.user_info).toHaveProperty('first_name');
+    expect(translatedObj.user_info).toHaveProperty('last_name');
+    expect(translatedObj.user_info).toHaveProperty('password');
+    expect(translatedObj.user_info).not.toHaveProperty('firstName');
+    expect(translatedObj.user_info).not.toHaveProperty('lastName');
+    expect(translatedObj.user_info.first_name).toEqual('jacob');
+    expect(translatedObj.user_info.last_name).toEqual('eckert');
+    expect(translatedObj.user_info.password).toEqual('test');
+
+    // check nested string array
+    expect(translatedObj.favorite_colors).toHaveLength(3);
+    expect(translatedObj.favorite_colors).toEqual(expect.arrayContaining([ 'red', 'green', 'blue' ]));
+
+    // check nested array of objects
+    expect(translatedObj.favorite_songs).toHaveLength(2);
+    expect(translatedObj.favorite_songs[0]).toHaveProperty('song_name');
+    expect(translatedObj.favorite_songs[0]).toHaveProperty('artist_name');
+    expect(translatedObj.favorite_songs[0]).not.toHaveProperty('songName');
+    expect(translatedObj.favorite_songs[0]).not.toHaveProperty('artistName');
+
+    expect(translatedObj.favorite_songs[1]).toHaveProperty('song_name');
+    expect(translatedObj.favorite_songs[1]).toHaveProperty('artist_name');
+    expect(translatedObj.favorite_songs[1]).not.toHaveProperty('songName');
+    expect(translatedObj.favorite_songs[1]).not.toHaveProperty('artistName');
+
+    expect(translatedObj.favorite_songs[0].song_name).toEqual('Save a Secret for the Moon');
+    expect(translatedObj.favorite_songs[0].artist_name).toEqual('The Magnetic Fields');
+
+    expect(translatedObj.favorite_songs[1].song_name).toEqual('Baby');
+    expect(translatedObj.favorite_songs[1].artist_name).toEqual('of Montreal');
+  });
+
+  test('should properly convert top-level arrays of objects', () => {
+    const arr = [
+      { firstName: 'jacob', lastName: 'eckert' },
+      { firstName: 'test', lastName: 'user' }
+    ];
+
+    const translatedObj = translateObjectKeys(arr, convertCamelToSnake);
+
+    expect(translatedObj).toHaveLength(2);
+    expect(translatedObj[0]).toHaveProperty('first_name');
+    expect(translatedObj[0]).toHaveProperty('last_name');
+    expect(translatedObj[0]).not.toHaveProperty('firstName');
+    expect(translatedObj[0]).not.toHaveProperty('lastName');
+
+    expect(translatedObj[1]).toHaveProperty('first_name');
+    expect(translatedObj[1]).toHaveProperty('last_name');
+    expect(translatedObj[1]).not.toHaveProperty('firstName');
+    expect(translatedObj[1]).not.toHaveProperty('lastName');
+
+    expect(translatedObj[0].first_name).toEqual('jacob');
+    expect(translatedObj[0].last_name).toEqual('eckert');
+    expect(translatedObj[1].first_name).toEqual('test');
+    expect(translatedObj[1].last_name).toEqual('user');
+  });
+
+  test('should properly handle top-level arrays of primitives', () => {
+    const arr = [ 1, 'string', null, undefined ];
+
+    const translatedObj = translateObjectKeys(arr, convertCamelToSnake);
+
+    expect(translatedObj).toHaveLength(4);
+    expect(translatedObj).toEqual(expect.arrayContaining([ 1, 'string', null, undefined ]));
   });
 });


### PR DESCRIPTION
Added logic to handle nested objects or arrays, as well as top-level arrays for `translateObjectKeys`. I am well aware this is a wildly overengineered solution to a problem that would be better suited for just hardcoding probably but goddamnit it was so fun to write just let me have it please this is my own personal project okay.