### PR TITLE
Artist form

### DIFF
--- a/src/api/artist.js
+++ b/src/api/artist.js
@@ -1,0 +1,8 @@
+import { request } from '../utils/request';
+
+export const artist = {
+  create: async artistData => {
+    const artist = await request('/artists', 'POST', artistData);
+    return artist;
+  }
+}

--- a/src/api/artists.js
+++ b/src/api/artists.js
@@ -1,6 +1,6 @@
 import { request } from '../utils/request';
 
-export const artist = {
+export const artists = {
   create: async artistData => {
     const artist = await request('/artists', 'POST', artistData);
     return artist;

--- a/src/api/artists.js
+++ b/src/api/artists.js
@@ -4,5 +4,15 @@ export const artists = {
   create: async artistData => {
     const artist = await request('/artists', 'POST', artistData);
     return artist;
+  },
+
+  get: async artistId => {
+    const artist = await request(`/artists/${artistId}`);
+    return artist;
+  },
+
+  update: async (artistId, artistData) => {
+    const artist = await request(`/artists/${artistId}`, 'PUT', artistData);
+    return artist;
   }
 }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,9 +1,11 @@
 import { auth } from './auth';
 import { user } from './user';
 import { stats } from './stats';
+import { artist } from './artist';
 
 export const api = {
   auth,
   user,
-  stats
+  stats,
+  artist
 };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,11 +1,11 @@
 import { auth } from './auth';
 import { user } from './user';
 import { stats } from './stats';
-import { artist } from './artist';
+import { artists } from './artists';
 
 export const api = {
   auth,
   user,
   stats,
-  artist
+  artists
 };

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -3,6 +3,7 @@ import { Route, Switch, Redirect } from 'react-router-dom';
 
 import { Home } from './home/Home';
 import { ContributePage } from './contribute/ContributePage';
+import { ArtistForm } from './artist/ArtistForm';
 import { Logout } from './auth/Logout';
 
 export const ApplicationViews = () => {
@@ -22,6 +23,10 @@ export const ApplicationViews = () => {
 
       <Route path="/contribute">
         <ContributePage />
+      </Route>
+
+      <Route path="/artists/new">
+        <ArtistForm />
       </Route>
 
       <Route path="/me">

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -4,6 +4,7 @@ import { Route, Switch, Redirect } from 'react-router-dom';
 import { Home } from './home/Home';
 import { ContributePage } from './contribute/ContributePage';
 import { ArtistForm } from './artist/ArtistForm';
+import { ArtistEditForm } from './artist/ArtistEditForm';
 import { Logout } from './auth/Logout';
 
 export const ApplicationViews = () => {
@@ -24,6 +25,11 @@ export const ApplicationViews = () => {
       <Route path="/contribute">
         <ContributePage />
       </Route>
+
+      <Route path="/artists/:artistId(\d+)/edit" render={props => {
+        const { artistId } = props.match.params;
+        return <ArtistEditForm artistId={artistId} />;
+      }} />
 
       <Route path="/artists/new">
         <ArtistForm />

--- a/src/components/artist/ArtistEditForm.js
+++ b/src/components/artist/ArtistEditForm.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { api } from '../../api';
+import { useApi } from '../../api/useApi';
+import { LoadingIndicator, WarningText } from '../common';
+import { ArtistForm } from './ArtistForm';
+
+export const ArtistEditForm = props => {
+  const { artistId } = props;
+
+  const [ artist, isLoading, error ] = useApi(api.artists.get, artistId);
+
+  return <>
+    <LoadingIndicator isLoading={isLoading} />
+    <WarningText>{error}</WarningText>
+    { artist && <ArtistForm artist={artist} /> }
+  </>;
+};

--- a/src/components/artist/ArtistEditForm.test.js
+++ b/src/components/artist/ArtistEditForm.test.js
@@ -16,8 +16,7 @@ describe('artist edit form functionality', () => {
     expect(mockGetArtist).toHaveBeenCalledTimes(1);
     expect(mockGetArtist).toHaveBeenCalledWith(1);
 
-    const formHeading = await screen.findByRole('heading');
-    expect(formHeading.textContent).toEqual('Edit Artist');
+    expect(await screen.findByRole('form')).toBeInTheDocument();
 
     expect(screen.getByLabelText('Name')).toEqual(screen.getByDisplayValue('of Montreal'));
     expect(screen.getByLabelText('Year Founded')).toEqual(screen.getByDisplayValue('1996'));

--- a/src/components/artist/ArtistEditForm.test.js
+++ b/src/components/artist/ArtistEditForm.test.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { api } from '../../api';
+import { ArtistEditForm } from './ArtistEditForm';
+
+jest.mock('../../api');
+const mockGetArtist = (api.artists.get = jest.fn());
+
+describe('artist edit form functionality', () => {
+  test('fetches artist with id passed in props on load and renders edit form with artist data prepopulated', async () => {
+    mockGetArtist.mockResolvedValueOnce({ id: 1, name: 'of Montreal', foundedYear: 1996, description: 'The band.' });
+
+    render(<ArtistEditForm artistId={1} />);
+
+    expect(mockGetArtist).toHaveBeenCalledTimes(1);
+    expect(mockGetArtist).toHaveBeenCalledWith(1);
+
+    const formHeading = await screen.findByRole('heading');
+    expect(formHeading.textContent).toEqual('Edit Artist');
+
+    expect(screen.getByLabelText('Name')).toEqual(screen.getByDisplayValue('of Montreal'));
+    expect(screen.getByLabelText('Year Founded')).toEqual(screen.getByDisplayValue('1996'));
+    expect(screen.getByLabelText('Description')).toEqual(screen.getByDisplayValue('The band.'));
+  });
+
+  test('renders error message if artist load error occurred', async () => {
+    mockGetArtist.mockRejectedValueOnce({ message: 'Artist load failed.' });
+
+    render(<ArtistEditForm artistId={1} />);
+
+    expect(await screen.findByText('Artist load failed.')).toBeInTheDocument();
+    expect(screen.queryByRole('form')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/artist/ArtistForm.js
+++ b/src/components/artist/ArtistForm.js
@@ -14,8 +14,15 @@ const artistFormSchema = yup.object().shape({
 });
 
 export const ArtistForm = props => {
+  const { artist } = props;
+
   const { register, handleSubmit, errors } = useForm({
-    resolver: yupResolver(artistFormSchema)
+    resolver: yupResolver(artistFormSchema),
+    defaultValues: {
+      name: artist?.name || '',
+      foundedYear: artist?.foundedYear || '',
+      description: artist?.description || ''
+    }
   });
 
   const [ error, setError ] = useState('');
@@ -24,8 +31,8 @@ export const ArtistForm = props => {
 
   const onSubmit = async artistData => {
     try {
-      const artist = await api.artists.create(artistData);
-      history.push(`/artists/${artist.id}`);
+      const artistResponse = artist ? await api.artists.update(artist.id, artistData) : await api.artists.create(artistData);
+      history.push(`/artists/${artistResponse.id}`);
     }
     catch(e) {
       setError(e.message);
@@ -34,7 +41,7 @@ export const ArtistForm = props => {
 
   return (
     <form className="max-w-screen-lg mx-auto" onSubmit={handleSubmit(onSubmit)}>
-      <h2 className="text-2xl text-center">New <span className="text-deepred">Artist</span></h2>
+      <h2 className="text-2xl text-center">{ artist ? 'Edit' : 'New' } <span className="text-deepred">Artist</span></h2>
 
       <WarningText>{error}</WarningText>
 

--- a/src/components/artist/ArtistForm.js
+++ b/src/components/artist/ArtistForm.js
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
+import { useHistory } from 'react-router-dom';
 
 import { api } from '../../api';
-import { Button, FormControl } from '../common';
+import { Button, FormControl, WarningText } from '../common';
 
 const artistFormSchema = yup.object().shape({
   name: yup.string().required('Artist name is required.'),
@@ -17,13 +18,25 @@ export const ArtistForm = props => {
     resolver: yupResolver(artistFormSchema)
   });
 
+  const [ error, setError ] = useState('');
+
+  const history = useHistory();
+
   const onSubmit = async artistData => {
-    console.log(artistData);
+    try {
+      const artist = await api.artists.create(artistData);
+      history.push(`/artists/${artist.id}`);
+    }
+    catch(e) {
+      setError(e.message);
+    }
   };
 
   return (
     <form className="max-w-screen-lg mx-auto" onSubmit={handleSubmit(onSubmit)}>
-      <h2>New <span className="text-deepred">Artist</span></h2>
+      <h2 className="text-2xl text-center">New <span className="text-deepred">Artist</span></h2>
+
+      <WarningText>{error}</WarningText>
 
       <FormControl name="name"
         label="Name"

--- a/src/components/artist/ArtistForm.js
+++ b/src/components/artist/ArtistForm.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import * as yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
+
+import { api } from '../../api';
+import { Button, FormControl } from '../common';
+
+const artistFormSchema = yup.object().shape({
+  name: yup.string().required('Artist name is required.'),
+  foundedYear: yup.number().typeError('Founded year must be a number.').required('Founded year is required.').integer('Founded year must be a whole number.').min(1850, 'Year must be on or after 1850.').max((new Date()).getFullYear(), 'Year must be on or earlier than the current year.'),
+  description: yup.string().required('Description is required.')
+});
+
+export const ArtistForm = props => {
+  const { register, handleSubmit, errors } = useForm({
+    resolver: yupResolver(artistFormSchema)
+  });
+
+  const onSubmit = async artistData => {
+    console.log(artistData);
+  };
+
+  return (
+    <form className="max-w-screen-lg mx-auto" onSubmit={handleSubmit(onSubmit)}>
+      <h2>New <span className="text-deepred">Artist</span></h2>
+
+      <FormControl name="name"
+        label="Name"
+        register={register}
+        error={errors.name?.message} />
+
+      <FormControl name="foundedYear"
+        label="Year Founded"
+        register={register}
+        error={errors.foundedYear?.message} />
+
+      <FormControl name="description"
+        type="textarea"
+        label="Description"
+        register={register}
+        error={errors.description?.message} />
+
+      <Button type="submit">Create Artist</Button>
+    </form>
+  );
+};

--- a/src/components/artist/ArtistForm.js
+++ b/src/components/artist/ArtistForm.js
@@ -40,8 +40,8 @@ export const ArtistForm = props => {
   };
 
   return (
-    <form className="max-w-screen-lg mx-auto" onSubmit={handleSubmit(onSubmit)}>
-      <h2 className="text-2xl text-center">{ artist ? 'Edit' : 'New' } <span className="text-deepred">Artist</span></h2>
+    <form className="max-w-screen-lg mx-auto" onSubmit={handleSubmit(onSubmit)} aria-labelledby="artist-form-title">
+      <h2 id="artist-form-title" className="text-2xl text-center">{ artist ? 'Edit' : 'New' } <span className="text-deepred">Artist</span></h2>
 
       <WarningText>{error}</WarningText>
 
@@ -61,7 +61,7 @@ export const ArtistForm = props => {
         register={register}
         error={errors.description?.message} />
 
-      <Button type="submit">Create Artist</Button>
+      <Button type="submit" className="ml-auto">{ artist ? 'Update' : 'Create' } Artist</Button>
     </form>
   );
 };

--- a/src/components/artist/ArtistForm.test.js
+++ b/src/components/artist/ArtistForm.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ArtistForm } from './ArtistForm';
+
+describe('artist form validation', () => {
+  test('all fields are required', async () => {
+    render(<ArtistForm />);
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(await screen.findByText('Artist name is required.')).toBeInTheDocument();
+    expect(await screen.findByText('Founded year must be a number.')).toBeInTheDocument();
+    expect(await screen.findByText('Description is required.')).toBeInTheDocument();
+  });
+
+  test('year founded must be >= 1850', async () => {
+    render(<ArtistForm />);
+
+    await userEvent.type(screen.getByLabelText('Year Founded'), '1849');
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(await screen.findByText('Year must be on or after 1850.')).toBeInTheDocument();
+  });
+
+  test('year founded must be <= current year', async () => {
+    const currentYear = (new Date()).getFullYear();
+
+    render(<ArtistForm />);
+
+    await userEvent.type(screen.getByLabelText('Year Founded'), String(currentYear + 1));
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(await screen.findByText(`Year must be on or earlier than the current year.`)).toBeInTheDocument();
+  });
+});

--- a/src/components/artist/ArtistForm.test.js
+++ b/src/components/artist/ArtistForm.test.js
@@ -1,8 +1,14 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 
 import { ArtistForm } from './ArtistForm';
+import { api } from '../../api';
+
+jest.mock('../../api');
+const mockPostArtist = (api.artists.create = jest.fn());
 
 describe('artist form validation', () => {
   test('all fields are required', async () => {
@@ -33,5 +39,50 @@ describe('artist form validation', () => {
     await userEvent.click(screen.getByRole('button'));
 
     expect(await screen.findByText(`Year must be on or earlier than the current year.`)).toBeInTheDocument();
+  });
+});
+
+describe('artist form functionality', () => {
+  const renderComponent = ui => {
+    const history = createMemoryHistory();
+
+    render(<Router history={history}>{ui}</Router>);
+
+    return history;
+  };
+
+  test('calls artist create api function on submit and redirects to artist page', async () => {
+    mockPostArtist.mockImplementationOnce(artistData => Promise.resolve({ ...artistData, id: 1 }));
+
+    const history = renderComponent(<ArtistForm />);
+
+    await userEvent.type(screen.getByLabelText('Name'), 'of Montreal');
+    await userEvent.type(screen.getByLabelText('Year Founded'), '1996');
+    await userEvent.type(screen.getByLabelText('Description'), 'The best out of Athens.');
+    await userEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(mockPostArtist).toHaveBeenCalledTimes(1));
+    expect(mockPostArtist).toHaveBeenCalledWith({
+      name: 'of Montreal',
+      foundedYear: 1996,
+      description: 'The best out of Athens.'
+    });
+
+    await waitFor(() => expect(history.location.pathname).toEqual('/artists/1'));
+  });
+
+  test('renders error message if artist create failed', async () => {
+    mockPostArtist.mockRejectedValueOnce({ message: 'Artist creation failed.' });
+
+    render(<ArtistForm />);
+
+    await userEvent.type(screen.getByLabelText('Name'), 'of Montreal');
+    await userEvent.type(screen.getByLabelText('Year Founded'), '1996');
+    await userEvent.type(screen.getByLabelText('Description'), 'The best out of Athens.');
+    await userEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(mockPostArtist).toHaveBeenCalledTimes(1));
+
+    expect(await screen.findByText('Artist creation failed.')).toBeInTheDocument();
   });
 });

--- a/src/components/artist/ArtistForm.test.js
+++ b/src/components/artist/ArtistForm.test.js
@@ -52,6 +52,27 @@ describe('artist form functionality', () => {
     return history;
   };
 
+  test('renders create / new text when no artist passed in as props', () => {
+    render(<ArtistForm />);
+
+    expect(screen.getByRole('heading').textContent).toEqual('New Artist');
+    expect(screen.getByRole('button').textContent).toEqual('Create Artist');
+  });
+
+  test('renders edit / update text when artist passed in as props', () => {
+    const artist = {
+      id: 2,
+      name: 'of Montreal',
+      foundedYear: 1996,
+      description: 'So good.'
+    };
+
+    render(<ArtistForm artist={artist} />);
+
+    expect(screen.getByRole('heading').textContent).toEqual('Edit Artist');
+    expect(screen.getByRole('button').textContent).toEqual('Update Artist');
+  });
+
   test('calls artist create api function on submit and redirects to artist page', async () => {
     mockPostArtist.mockImplementationOnce(artistData => Promise.resolve({ ...artistData, id: 1 }));
 

--- a/src/components/common/FormControl.js
+++ b/src/components/common/FormControl.js
@@ -10,7 +10,7 @@ export const FormControl = props => {
       case "password":
         return <input className="p-2" type="password" name={name} id={name} ref={register} />;
       case "textarea":
-        return <textarea name={name} id={name} ref={register} />
+        return <textarea className="p-2" name={name} id={name} ref={register} />
       default:
         return <input className="p-2" type="text" name={name} id={name} ref={register} />;
     }


### PR DESCRIPTION
This PR implements an ArtistForm that can be used to both create a new artist or edit an existing artist. It sets up the routing to both an artist create view and an artist edit view. It adds tests for artist creation and editing.