### PR TITLE
Enhancement/add click outside to autocomplete search bar

### DIFF
--- a/src/components/common/AutocompleteSearchBar.js
+++ b/src/components/common/AutocompleteSearchBar.js
@@ -1,12 +1,17 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 
 import { DelayedSearchBar } from './DelayedSearchBar';
+import { useClickOutside } from '../../hooks';
 
 export const AutocompleteSearchBar = props => {
   const { onSearch, onSelect, className, name, placeholder, removeOnSelect, resultFormatter } = props;
 
   const [ results, setResults ] = useState([]);
   const [ isRefreshing, setIsRefreshing ] = useState(false);
+
+  const clickOutsideHandler = useCallback(() => setResults([]), [ ]);
+  const searchBarComponentRef = useRef();
+  useClickOutside(searchBarComponentRef, clickOutsideHandler);
 
   useEffect(() => {
     if(isRefreshing) {
@@ -33,7 +38,7 @@ export const AutocompleteSearchBar = props => {
   };
 
   return (
-    <div className="flex flex-col">
+    <div ref={searchBarComponentRef } className="flex flex-col">
       { !isRefreshing && <DelayedSearchBar className={className} 
         name={name} 
         placeholder={placeholder}

--- a/src/components/common/AutocompleteSearchBar.test.js
+++ b/src/components/common/AutocompleteSearchBar.test.js
@@ -48,4 +48,47 @@ describe('autocomplete search bar functionality', () => {
     expect(mockSelectHandler).toHaveBeenCalledTimes(1);
     expect(mockSelectHandler).toHaveBeenCalledWith({ id: 1, name: 'The Magnetic Fields' });
   });
+
+  test('clicking outside of the component when results are showing stops the results from showing', async () => {
+    mockSearch.mockResolvedValue([ { id: 1, name: 'The Magnetic Fields' }]);
+
+    render(
+      <div>
+        <p data-testid="1234">Click me</p>
+        <AutocompleteSearchBar onSearch={mockSearch} />
+      </div>
+    );
+
+    await waitFor(() => userEvent.type(screen.getByRole('textbox'), 'a'));
+    await waitFor(() => jest.advanceTimersByTime(500));
+
+    const selectButton = await screen.findByRole('button');
+    expect(selectButton).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('1234'));
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  test('clicking back inside of the component after clicking outside will show the previous results again', async () => {
+    mockSearch.mockResolvedValue([ { id: 1, name: 'The Magnetic Fields' }]);
+
+    render(
+      <div>
+        <p data-testid="1234">Click me</p>
+        <AutocompleteSearchBar onSearch={mockSearch} />
+      </div>
+    );
+
+    await waitFor(() => userEvent.type(screen.getByRole('textbox'), 'a'));
+    await waitFor(() => jest.advanceTimersByTime(500));
+
+    await userEvent.click(screen.getByTestId('1234'));
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('textbox'));
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('The Magnetic Fields');
+  });
 });

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,7 +1,9 @@
 import { useApi } from './useApi';
 import { useDebounce } from './useDebounce';
+import { useClickOutside } from './useClickOutside';
 
 export {
   useApi,
-  useDebounce
+  useDebounce,
+  useClickOutside
 };

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,9 +1,11 @@
 import { useApi } from './useApi';
 import { useDebounce } from './useDebounce';
 import { useClickOutside } from './useClickOutside';
+import { useClickInside } from './useClickInside';
 
 export {
   useApi,
   useDebounce,
-  useClickOutside
+  useClickOutside,
+  useClickInside
 };

--- a/src/hooks/useClickInside.js
+++ b/src/hooks/useClickInside.js
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+export const useClickInside = (ref, handler) => {
+  useEffect(() => {
+    const listener = e => {
+      if(!ref.current || ref.current.contains(e.target)) {
+        handler(e);
+      }
+    };
+
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [ ref, handler ]);
+};

--- a/src/hooks/useClickOutside.js
+++ b/src/hooks/useClickOutside.js
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+export const useClickOutside = (ref, handler) => {
+  useEffect(() => {
+    const listener = e => {
+      if(!ref.current || ref.current.contains(e.target)) {
+        return;
+      }
+
+      handler(e);
+    };
+
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [ ref, handler ]);
+};


### PR DESCRIPTION
This PR adds click outside / inside functionality to the AutocompleteSearchBar. If there are results and the users clicks outside of the search bar, the results are cached in a separate state variable and then the displayed ones are removed. If the user clicks into it and there are cached results, the results get reset back to the cached ones and the cached ones are cleared.