### PR TITLE
Enhancement/player improvements

### DIFF
--- a/src/components/artist/ArtistPage.test.js
+++ b/src/components/artist/ArtistPage.test.js
@@ -13,12 +13,13 @@ const mockGetArtist = (api.artists.get = jest.fn());
 const mockListSongs = (api.songs.list = jest.fn());
 
 const mockSetQueue = jest.fn();
+const mockPlayQueue = jest.fn();
 
 const renderComponent = ui => {
   const history = createMemoryHistory();
 
   render(
-    <PlayerContext.Provider value={{ setQueue: mockSetQueue }}>
+    <PlayerContext.Provider value={{ setQueue: mockSetQueue, playQueue: mockPlayQueue }}>
       <Router history={history}>
         {ui}
       </Router>
@@ -113,5 +114,7 @@ describe('artist page functionality', () => {
 
     expect(mockSetQueue).toHaveBeenCalledTimes(1);
     expect(mockSetQueue).toHaveBeenCalledWith(songsResponse);
+
+    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/chart/Chart.test.js
+++ b/src/components/chart/Chart.test.js
@@ -13,10 +13,11 @@ jest.mock('../../api');
 const mockListSongs = (api.songs.list = jest.fn());
 const mockSearchGenres = (api.genres.search = jest.fn());
 const mockSetQueue = jest.fn();
+const mockPlayQueue = jest.fn();
 
 const renderComponent = ui => {
   render(
-    <PlayerContext.Provider value={{ setQueue: mockSetQueue }}>
+    <PlayerContext.Provider value={{ setQueue: mockSetQueue, playQueue: mockPlayQueue }}>
       <Router history={createMemoryHistory()}>
         {ui}
       </Router>
@@ -153,5 +154,7 @@ describe('chart functionality', () => {
 
     expect(mockSetQueue).toHaveBeenCalledTimes(1);
     expect(mockSetQueue).toHaveBeenCalledWith(SONGS_RESPONSE);
+    
+    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/list/ListDetail.test.js
+++ b/src/components/list/ListDetail.test.js
@@ -8,12 +8,13 @@ import { ListDetail } from './ListDetail';
 import { PlayerContext } from '../player/PlayerProvider';
 
 const mockSetQueue = jest.fn();
+const mockPlayQueue = jest.fn();
 
 const renderComponent = ui => {
   const history = createMemoryHistory();
 
   render(
-    <PlayerContext.Provider value={{ setQueue: mockSetQueue }}>
+    <PlayerContext.Provider value={{ setQueue: mockSetQueue, playQueue: mockPlayQueue }}>
       <Router history={history}>{ui}</Router>
     </PlayerContext.Provider>
   );
@@ -156,5 +157,7 @@ describe('list detail functionality', () => {
         ]
       }
     ]);
+
+    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/player/PlayButton.js
+++ b/src/components/player/PlayButton.js
@@ -5,10 +5,15 @@ import { PlayerContext } from './PlayerProvider';
 
 export const PlayButton = props => {
   const { songs, className, accessibleName } = props;
-  const { setQueue } = useContext(PlayerContext);
+  const { setQueue, playQueue } = useContext(PlayerContext);
+
+  const handleClick = () => {
+    setQueue([ ...songs ]);
+    playQueue();
+  }
 
   return (
-    <button onClick={() => setQueue([ ...songs ])}
+    <button onClick={handleClick}
       className={`bg-transparent hover:text-deepred ${className || ''}`}>
         <MdPlayCircleFilled />
         <span className="sr-only">{accessibleName || "Play Songs"}</span>

--- a/src/components/player/PlayButton.test.js
+++ b/src/components/player/PlayButton.test.js
@@ -6,10 +6,11 @@ import { PlayButton } from './PlayButton';
 import { PlayerContext } from './PlayerProvider';
 
 const mockSetQueue = jest.fn();
+const mockPlayQueue = jest.fn();
 
 const renderComponent = ui => {
   render(
-    <PlayerContext.Provider value={{ setQueue: mockSetQueue }}>
+    <PlayerContext.Provider value={{ setQueue: mockSetQueue, playQueue: mockPlayQueue }}>
       { ui }
     </PlayerContext.Provider>
   );
@@ -27,5 +28,6 @@ describe('play button functionality', () => {
     await userEvent.click(screen.getByText('Play All Magnetic Fields Songs'));
     expect(mockSetQueue).toHaveBeenCalledTimes(1);
     expect(mockSetQueue).toHaveBeenLastCalledWith([ { id: 1, name: 'Save a Secret for the Moon' } ]);
+    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/player/PlayerContainer.js
+++ b/src/components/player/PlayerContainer.js
@@ -8,7 +8,7 @@ import { Player } from './Player';
 export const PlayerContainer = () => {
   const [ isExpanded, setIsExpanded ] = useState(false);
 
-  const { isPlaying } = useContext(PlayerContext);
+  const { isPlaying, queue } = useContext(PlayerContext);
 
   useEffect(() => {
     if(isExpanded) document.body.style = 'margin-bottom: 10rem;';
@@ -16,8 +16,8 @@ export const PlayerContainer = () => {
   }, [ isExpanded ]);
 
   useEffect(() => {
-    if(isPlaying) setIsExpanded(true);
-  }, [ isPlaying ]);
+    if(isPlaying && queue) setIsExpanded(true);
+  }, [ isPlaying, queue ]);
 
   return (
     <div style={{ height: isExpanded ? '10rem' : '5rem' }}

--- a/src/components/player/PlayerContainer.js
+++ b/src/components/player/PlayerContainer.js
@@ -13,6 +13,8 @@ export const PlayerContainer = () => {
   useEffect(() => {
     if(isExpanded) document.body.style = 'margin-bottom: 10rem;';
     else document.body.style = 'margin-bottom: 5rem;';
+
+    return () => document.body.style = 'margin-bottom: 0';
   }, [ isExpanded ]);
 
   useEffect(() => {

--- a/src/components/player/PlayerProvider.js
+++ b/src/components/player/PlayerProvider.js
@@ -25,6 +25,7 @@ export const PlayerProvider = props => {
 
   const { user } = useContext(UserContext);
 
+  // on user state change, try to restore the queue for the user from local storage
   useEffect(() => {
     if(user) {
       const restoredQueue = localStorage.getItem(`${user.id}_playerState`);
@@ -37,6 +38,7 @@ export const PlayerProvider = props => {
     }
   }, [ user, setQueue, setPlayIndex ]);
 
+  // on user and queue change, serialize the current minimal queue state to local storage
   useEffect(() => {
     if(user && queue?.length) {
       const toSerialize = {

--- a/src/components/player/PlayerProvider.js
+++ b/src/components/player/PlayerProvider.js
@@ -50,12 +50,10 @@ export const PlayerProvider = props => {
     }
   }, [ user, playIndex, queue ]);
 
-  useEffect(() => {
-    if(queue.length && isPlaying === null) {
-      setIsPlaying(true);
-      setPlayIndex(0);
-    }
-  }, [ queue, isPlaying ]);
+  const playQueue = () => {
+    setIsPlaying(true);
+    setPlayIndex(0);
+  }
 
   const play = () => {
     setIsPlaying(true);
@@ -75,7 +73,7 @@ export const PlayerProvider = props => {
 
   return (
     <PlayerContext.Provider value={{
-      queue, setQueue, play, pause, skip, setIsPlaying, isPlaying, currentSong, currentSongUrl
+      queue, setQueue, playQueue, play, pause, skip, setIsPlaying, isPlaying, currentSong, currentSongUrl
     }}>
       { props.children }
     </PlayerContext.Provider>

--- a/src/components/player/PlayerProvider.js
+++ b/src/components/player/PlayerProvider.js
@@ -32,7 +32,7 @@ export const PlayerProvider = props => {
 
   return (
     <PlayerContext.Provider value={{
-      setQueue, play, pause, skip, setIsPlaying, isPlaying, currentSong, currentSongUrl
+      queue, setQueue, play, pause, skip, setIsPlaying, isPlaying, currentSong, currentSongUrl
     }}>
       { props.children }
     </PlayerContext.Provider>

--- a/src/components/song/SongDetail.test.js
+++ b/src/components/song/SongDetail.test.js
@@ -8,12 +8,13 @@ import { SongDetail } from './SongDetail';
 import { PlayerContext } from '../player/PlayerProvider';
 
 const mockSetQueue = jest.fn();
+const mockPlayQueue = jest.fn();
 
 const renderComponent = ui => {
   const history = createMemoryHistory();
 
   render(
-    <PlayerContext.Provider value={{ setQueue: mockSetQueue }}>
+    <PlayerContext.Provider value={{ setQueue: mockSetQueue, playQueue: mockPlayQueue }}>
       <Router history={history}>
         {ui}
       </Router>
@@ -82,6 +83,8 @@ describe('song detail view functionality', () => {
       ]
     }]);
 
+    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
+
     const dropdown = screen.getByRole('combobox');
     await userEvent.selectOptions(dropdown, 'https://soundcloud.com/themagneticfields/famous-1');
 
@@ -100,5 +103,7 @@ describe('song detail view functionality', () => {
         { service: 'SoundCloud', url: 'https://soundcloud.com/themagneticfields/famous-1', isPrimary: false }
       ]
     }]);
+
+    expect(mockPlayQueue).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
This PR adds a couple cool features to the player. Now it will expand anytime you play something new, instead of just when you go from not playing something to playing something. And way cooler, it will serialize itself to and deserialize itself from local storage on a per-user basis. So you can logout or close your tab and then come back later and your queue will still be exactly where it was when you left.