### PR TITLE
Edit and delete controls

### DIFF
--- a/src/api/artists.js
+++ b/src/api/artists.js
@@ -22,6 +22,10 @@ export const artists = {
     return artists;
   },
 
+  delete: async artistId => {
+    return await request(`/artists/${artistId}`, 'DELETE');
+  },
+
   search: async searchTerm => {
     return await artists.list({ q: searchTerm });
   }

--- a/src/api/lists.js
+++ b/src/api/lists.js
@@ -22,6 +22,10 @@ export const lists = {
     return lists;
   },
 
+  delete: async listId => {
+    return await request(`/lists/${listId}`, 'DELETE');
+  },
+
   favorite: async listId => {
     return await request(`/lists/${listId}/favorite`, 'POST');
   },

--- a/src/api/songs.js
+++ b/src/api/songs.js
@@ -22,6 +22,10 @@ export const songs = {
     return songs;
   },
 
+  delete: async songId => {
+    return await request(`/songs/${songId}`, 'DELETE');
+  },
+
   search: async searchTerm => {
     return await songs.list({ q: searchTerm });
   }

--- a/src/components/artist/ArtistPage.js
+++ b/src/components/artist/ArtistPage.js
@@ -1,8 +1,7 @@
 import React, { useState, useContext } from 'react';
-import { useHistory } from 'react-router-dom';
 
 import { api } from '../../api';
-import { useApi, usePagination } from '../../hooks';
+import { useApi, useDeleteAndRedirect, usePagination } from '../../hooks';
 import { UserContext } from '../user/UserProvider';
 import { PlayButton } from '../player/PlayButton';
 import { SongList } from '../song/SongList';
@@ -11,8 +10,6 @@ import { Page, LoadingIndicator, WarningText, ListSortOptions, PaginationControl
 export const ArtistPage = props => {
   const { artistId } = props;
 
-  const history = useHistory();
-
   const { user } = useContext(UserContext);
 
   const [ orderBy, setOrderBy ] = useState({ orderBy: 'year', direction: 'desc' });
@@ -20,20 +17,10 @@ export const ArtistPage = props => {
   const [ artist, isArtistLoading, artistError ] = useApi(api.artists.get, artistId);
   const [ songsResponse, isSongsLoading, songsError ] = useApi(api.songs.list, { artist: artistId, ...orderBy, ...paginationParams });
 
-  const [ deleteError, setDeleteError ] = useState('');
+  const [ handleDelete, deleteError ] = useDeleteAndRedirect(api.artists.delete, artistId);
 
   const songs = songsResponse?.data;
   const songsCount = songsResponse?.count;
-
-  const handleDelete = async () => {
-    try {
-      await api.artists.delete(artistId);
-      history.push('/');
-    }
-    catch(e) {
-      setDeleteError(e.message);
-    }
-  };
 
   const renderArtistData = () => {
     if(!artist) return null;

--- a/src/components/common/DeleteButton.js
+++ b/src/components/common/DeleteButton.js
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { MdDelete } from 'react-icons/md';
+
+import { Modal } from './Modal';
+import { Button } from './Button';
+
+export const DeleteButton = props => {
+  const { onDelete, accessibleName, className } = props;
+
+  const [ isDeleting, setIsDeleting ] = useState(false);
+
+  const handleDelete = () => {
+    onDelete();
+    setIsDeleting(false);
+  };
+
+  return <>
+    <button className={`bg-red-300 hover:bg-red-400 px-2 ${className}`} onClick={() => setIsDeleting(true)}>
+      <MdDelete />
+      <span className="sr-only">{accessibleName}</span>
+    </button>
+
+    <Modal isShowing={isDeleting} onClose={() => setIsDeleting(false)}>
+      <div>
+        <p>Are you sure you want to delete this item? <strong>It will be deleted permanently!</strong></p>
+        <div className="flex justify-end mt-3">
+          <Button className="mr-3" onClick={() => setIsDeleting(false)}>Cancel</Button>
+          <Button className="bg-red-300 hover:bg-red-400" onClick={handleDelete}>Delete</Button>
+        </div>
+      </div>
+    </Modal>
+  </>;
+};

--- a/src/components/common/DeleteButton.js
+++ b/src/components/common/DeleteButton.js
@@ -25,7 +25,7 @@ export const DeleteButton = props => {
         <p>Are you sure you want to delete this item? <strong>It will be deleted permanently!</strong></p>
         <div className="flex justify-end mt-3">
           <Button className="mr-3" onClick={() => setIsDeleting(false)}>Cancel</Button>
-          <Button className="bg-red-300 hover:bg-red-400" onClick={handleDelete}>Delete</Button>
+          <Button className="bg-red-300 hover:bg-red-400" onClick={handleDelete}>Delete Forever</Button>
         </div>
       </div>
     </Modal>

--- a/src/components/common/DeleteButton.test.js
+++ b/src/components/common/DeleteButton.test.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { DeleteButton } from './DeleteButton';
+
+describe('delete button functionality', () => {
+  test('renders as a single button with accessible name initially', () => {
+    render(<DeleteButton accessibleName="Delete Me" />);
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.getByText('Delete Me')).toBeInTheDocument();
+  });
+
+  test('clicking on the button renders modal with delete warning, cancel, and delete buttons', async () => {
+    render(<DeleteButton accessibleName="Delete Me" />);
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByText('Are you sure you want to delete this item?')).toBeInTheDocument();
+
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(3);
+
+    expect(buttons[1]).toHaveTextContent('Cancel');
+    expect(buttons[2]).toHaveTextContent('Delete');
+  });
+
+  test('clicking the cancel button will close the modal and not call the delete handler', async () => {
+    const mockDeleteHandler = jest.fn();
+
+    render(<DeleteButton onDelete={mockDeleteHandler} />);
+
+    await userEvent.click(screen.getByRole('button'));
+    await userEvent.click(screen.getByText('Cancel'));
+
+    expect(await screen.findAllByRole('button')).toHaveLength(1);
+    expect(mockDeleteHandler).not.toHaveBeenCalled();
+  });
+
+  test('clicking the delete button in the modal will close the modal and call the delete handler', async () => {
+    const mockDeleteHandler = jest.fn();
+
+    render(<DeleteButton onDelete={mockDeleteHandler} />);
+
+    await userEvent.click(screen.getByRole('button'));
+    await userEvent.click(screen.getByText('Delete'));
+
+    expect(await screen.findAllByRole('button')).toHaveLength(1);
+    expect(mockDeleteHandler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/common/DeleteButton.test.js
+++ b/src/components/common/DeleteButton.test.js
@@ -23,7 +23,7 @@ describe('delete button functionality', () => {
     expect(buttons).toHaveLength(3);
 
     expect(buttons[1]).toHaveTextContent('Cancel');
-    expect(buttons[2]).toHaveTextContent('Delete');
+    expect(buttons[2]).toHaveTextContent('Delete Forever');
   });
 
   test('clicking the cancel button will close the modal and not call the delete handler', async () => {
@@ -44,7 +44,7 @@ describe('delete button functionality', () => {
     render(<DeleteButton onDelete={mockDeleteHandler} />);
 
     await userEvent.click(screen.getByRole('button'));
-    await userEvent.click(screen.getByText('Delete'));
+    await userEvent.click(screen.getByText('Delete Forever'));
 
     expect(await screen.findAllByRole('button')).toHaveLength(1);
     expect(mockDeleteHandler).toHaveBeenCalledTimes(1);

--- a/src/components/common/Modal.js
+++ b/src/components/common/Modal.js
@@ -1,0 +1,42 @@
+import React, { useEffect, useRef, useCallback } from 'react';
+
+import { useClickOutside, useDebounce } from '../../hooks';
+
+export const Modal = props => {
+  const { isShowing, onClose } = props;
+
+  const modalRef = useRef();
+
+  const debouncedIsShowing = useDebounce(isShowing, 150);
+
+  const handleClickOutside = useCallback(() => {
+    if(isShowing) {
+      onClose();
+    }
+  }, [ onClose ]);
+
+  useClickOutside(modalRef, handleClickOutside);
+
+  const handleEscape = useCallback(e => {
+    if(e.key === 'Escape') {
+      onClose();
+    }
+  }, [ onClose ]);
+
+  useEffect(() => {
+    if(isShowing) {
+      document.addEventListener('keydown', handleEscape);
+
+      return () => document.removeEventListener('keydown', handleEscape);
+    }
+  }, [ isShowing, handleEscape ]);
+
+  return <>
+    <div className={`opacity-0 transition-all duration-150 ${isShowing ? 'opacity-50 fixed top-0 left-0 w-full h-full bg-gray-900 z-20' : ''}`} />
+    <div style={{ maxHeight: '90vh' }} 
+      ref={modalRef} 
+      className={`fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 p-8 border border-black bg-white z-30 overflow-scroll transition-all duration-150 ${!isShowing ? 'opacity-0 invisible' : ''}`}>
+        { (isShowing || debouncedIsShowing) && props.children }
+    </div>
+  </>;
+};

--- a/src/components/common/Modal.test.js
+++ b/src/components/common/Modal.test.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Modal } from './Modal';
+
+describe('modal functionality', () => {
+  test('when not showing does not render children', () => {
+    render(<Modal isShowing={false}><p data-testid="123456">hi</p></Modal>);
+
+    expect(screen.queryByTestId('123456')).not.toBeInTheDocument();
+  });
+
+  test('renders children when showing', () => {
+    render(<Modal isShowing={true}><p data-testid="123456">hi</p></Modal>);
+
+    expect(screen.queryByTestId('123456')).toBeInTheDocument();
+  });
+
+  test('hitting the escape key calls onClose when modal is showing', async () => {
+    const mockCloseHandler = jest.fn();
+
+    render(<Modal isShowing={true} onClose={mockCloseHandler}><p data-testid="123456">hi</p></Modal>);
+
+    await userEvent.type(screen.getByTestId('123456'), '{esc}');
+
+    expect(mockCloseHandler).toHaveBeenCalledTimes(1);
+  });
+
+  test('hitting the escape key does not call onClose when modal is not showing', async () => {
+    const mockCloseHandler = jest.fn();
+
+    const { container } = render(<Modal isShowing={false} onClose={mockCloseHandler}><p data-testid="123456">hi</p></Modal>);
+
+    // have to test with fireEvent because userEvent type also involves a click (which will trigger the clickOutside handler)
+    fireEvent.keyDown(container, { key: 'Escape', code: 'Escape' });
+
+    expect(mockCloseHandler).toHaveBeenCalledTimes(0);
+  });
+
+  test('clicking outside of the modal will call onClose when modal is showing', async () => {
+    const mockCloseHandler = jest.fn();
+
+    render(
+      <div>
+        <p data-testid="outside">outside</p>
+        <Modal isShowing={true} onClose={mockCloseHandler}>
+          <p data-testid="123456">hi</p>
+        </Modal>
+      </div>
+    );
+
+    await userEvent.click(screen.getByTestId('outside'));
+
+    expect(mockCloseHandler).toHaveBeenCalledTimes(1);
+  });
+
+  test('clicking outside of the modal will not call onClose when modal is not showing', async () => {
+    const mockCloseHandler = jest.fn();
+
+    render(
+      <div>
+        <p data-testid="outside">outside</p>
+        <Modal isShowing={false} onClose={mockCloseHandler}>
+          <p data-testid="123456">hi</p>
+        </Modal>
+      </div>
+    );
+
+    await userEvent.click(screen.getByTestId('outside'));
+
+    expect(mockCloseHandler).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/components/common/PaginationControls.js
+++ b/src/components/common/PaginationControls.js
@@ -10,7 +10,7 @@ export const PaginationControls = props => {
       className={`mx-1 hover:text-gray-600 ${val === pageSize ? 'font-bold' : ''}`}>
         {val}
     </button>
-  )
+  );
 
   return (
     <div className="flex flex-col md:flex-row justify-between items-center relative my-2">

--- a/src/components/common/index.js
+++ b/src/components/common/index.js
@@ -1,7 +1,9 @@
 import { Page } from './Page';
 import { PaginationControls } from './PaginationControls';
 import { Button } from './Button';
+import { DeleteButton } from './DeleteButton';
 import { RemoveButton } from './RemoveButton';
+import { Modal } from './Modal';
 import { LinkButton } from './LinkButton';
 import { FormControl } from './FormControl';
 import { WarningText } from './WarningText';
@@ -14,7 +16,9 @@ export {
   Page,
   PaginationControls,
   Button,
+  DeleteButton,
   RemoveButton,
+  Modal,
   LinkButton,
   FormControl,
   WarningText,

--- a/src/components/list/ListPage.js
+++ b/src/components/list/ListPage.js
@@ -1,14 +1,17 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
 import { api } from '../../api';
 import { useApi } from '../../hooks';
-import { Page, LoadingIndicator, WarningText } from '../common';
+import { UserContext } from '../user/UserProvider';
+import { Page, LoadingIndicator, WarningText, LinkButton, DeleteButton } from '../common';
 import { ListDetail } from './ListDetail';
 import { ListSongList } from './ListSongList';
 import { ListFavoriteControl } from './ListFavoriteControl';
 
 export const ListPage = props => {
   const { listId } = props;
+
+  const { user } = useContext(UserContext);
 
   const [ list, isLoading, error, refreshList ] = useApi(api.lists.get, listId);
 
@@ -30,10 +33,19 @@ export const ListPage = props => {
         <WarningText>{error}</WarningText>
         { list && 
           <div className="flex justify-between items-start">
-            <ListDetail list={list} />           
-            <ListFavoriteControl favCount={list.favCount} 
-              isFavorited={list.hasRaterFavorited}
-              onClick={handleFavoriteClick} />
+            <ListDetail list={list} />
+            <div className="flex">
+              {
+                list.creator.id === user?.id && 
+                  <>
+                    <LinkButton className="mr-2" to={`/lists/${listId}/edit`}>edit</LinkButton>
+                    <DeleteButton className="mr-2" onDelete={() => console.log('hi')} />
+                  </>
+              }
+              <ListFavoriteControl favCount={list.favCount} 
+                isFavorited={list.hasRaterFavorited}
+                onClick={handleFavoriteClick} />
+            </div>
           </div>
         }
       </section>

--- a/src/components/list/ListPage.js
+++ b/src/components/list/ListPage.js
@@ -1,4 +1,5 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 
 import { api } from '../../api';
 import { useApi } from '../../hooks';
@@ -11,9 +12,12 @@ import { ListFavoriteControl } from './ListFavoriteControl';
 export const ListPage = props => {
   const { listId } = props;
 
+  const history = useHistory();
+
   const { user } = useContext(UserContext);
 
   const [ list, isLoading, error, refreshList ] = useApi(api.lists.get, listId);
+  const [ deleteError, setDeleteError ] = useState('');
 
   const handleFavoriteClick = async () => {
     if(list.hasRaterFavorited) {
@@ -26,11 +30,22 @@ export const ListPage = props => {
     refreshList();
   };
 
+  const handleDeleteList = async () => {
+    try {
+      await api.lists.delete(listId);
+      history.push('/');
+    }
+    catch(e) {
+      setDeleteError(e.message);
+    }
+  };
+
   return (
     <Page>
       <section>
         <LoadingIndicator isLoading={!list && isLoading} />
         <WarningText>{error}</WarningText>
+        <WarningText>{deleteError}</WarningText>
         { list && 
           <div className="flex justify-between items-start">
             <ListDetail list={list} />
@@ -39,7 +54,7 @@ export const ListPage = props => {
                 list.creator.id === user?.id && 
                   <>
                     <LinkButton className="mr-2" to={`/lists/${listId}/edit`}>edit</LinkButton>
-                    <DeleteButton className="mr-2" onDelete={() => console.log('hi')} />
+                    <DeleteButton className="mr-2" onDelete={handleDeleteList} accessibleName="Delete List" />
                   </>
               }
               <ListFavoriteControl favCount={list.favCount} 

--- a/src/components/list/ListPage.js
+++ b/src/components/list/ListPage.js
@@ -1,8 +1,7 @@
-import React, { useContext, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import React, { useContext } from 'react';
 
 import { api } from '../../api';
-import { useApi } from '../../hooks';
+import { useApi, useDeleteAndRedirect } from '../../hooks';
 import { UserContext } from '../user/UserProvider';
 import { Page, LoadingIndicator, WarningText, LinkButton, DeleteButton } from '../common';
 import { ListDetail } from './ListDetail';
@@ -12,12 +11,10 @@ import { ListFavoriteControl } from './ListFavoriteControl';
 export const ListPage = props => {
   const { listId } = props;
 
-  const history = useHistory();
-
   const { user } = useContext(UserContext);
 
   const [ list, isLoading, error, refreshList ] = useApi(api.lists.get, listId);
-  const [ deleteError, setDeleteError ] = useState('');
+  const [ handleDelete, deleteError ] = useDeleteAndRedirect(api.lists.delete, listId);
 
   const handleFavoriteClick = async () => {
     if(list.hasRaterFavorited) {
@@ -28,16 +25,6 @@ export const ListPage = props => {
     }
 
     refreshList();
-  };
-
-  const handleDeleteList = async () => {
-    try {
-      await api.lists.delete(listId);
-      history.push('/');
-    }
-    catch(e) {
-      setDeleteError(e.message);
-    }
   };
 
   return (
@@ -54,7 +41,7 @@ export const ListPage = props => {
                 list.creator.id === user?.id && 
                   <>
                     <LinkButton className="mr-2" to={`/lists/${listId}/edit`}>edit</LinkButton>
-                    <DeleteButton className="mr-2" onDelete={handleDeleteList} accessibleName="Delete List" />
+                    <DeleteButton className="mr-2" onDelete={handleDelete} accessibleName="Delete List" />
                   </>
               }
               <ListFavoriteControl favCount={list.favCount} 

--- a/src/components/list/ListPage.test.js
+++ b/src/components/list/ListPage.test.js
@@ -1,19 +1,30 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 
 import { ListPage } from './ListPage';
 import { api } from '../../api';
 import { PlayerContext } from '../player/PlayerProvider';
+import { UserContext } from '../user/UserProvider';
 
 jest.mock('../../api');
 const mockGetList = (api.lists.get = jest.fn());
 
 const renderComponent = ui => {
+  const history = createMemoryHistory();
+
   render(
-    <PlayerContext.Provider value={{ setQueue: jest.fn() }}>
-      {ui}
-    </PlayerContext.Provider>
-  )
+    <UserContext.Provider value={{ user: { id: 2 } }}>
+      <PlayerContext.Provider value={{ setQueue: jest.fn() }}>
+        <Router history={history}>
+          {ui}
+        </Router>
+      </PlayerContext.Provider>
+    </UserContext.Provider>
+  );
+
+  return history;
 };
 
 describe('list page functionality', () => {

--- a/src/components/list/ListPage.test.js
+++ b/src/components/list/ListPage.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 
@@ -10,12 +11,51 @@ import { UserContext } from '../user/UserProvider';
 
 jest.mock('../../api');
 const mockGetList = (api.lists.get = jest.fn());
+const mockDeleteList = (api.lists.delete = jest.fn());
+const mockFavoriteList = (api.lists.favorite = jest.fn());
+const mockUnfavoriteList = (api.lists.unfavorite = jest.fn());
 
-const renderComponent = ui => {
+const LIST_RESPONSE = {
+  id: 8,
+  name: 'My favorite songs',
+  description: 'Some good tunes',
+  songs: [
+    { 
+      id: 1, 
+      song: {
+        id: 1,
+        name: 'Save a Secret for the Moon',
+        year: 1996,
+        artist: {
+          id: 1,
+          name: 'The Magnetic Fields'
+        },
+        sources: [
+          {
+            "id": 3,
+            "url": "https://www.youtube.com/watch?v=4rk_9cYOp8A",
+            "service": "YouTube",
+            "is_primary": true,
+            "song": 3
+          }
+        ]
+      },
+      description: 'Secret saving.'
+    }
+  ],
+  creator: {
+    id: 2,
+    user: {
+      username: 'jweckert17'
+    }
+  }
+};
+
+const renderComponentAsUser = (ui, userId) => {
   const history = createMemoryHistory();
 
   render(
-    <UserContext.Provider value={{ user: { id: 2 } }}>
+    <UserContext.Provider value={{ user: { id: userId } }}>
       <PlayerContext.Provider value={{ setQueue: jest.fn() }}>
         <Router history={history}>
           {ui}
@@ -29,9 +69,74 @@ const renderComponent = ui => {
 
 describe('list page functionality', () => {
   test('should get list by id on load', async () => {
-    await waitFor(() => renderComponent(<ListPage listId={8} />));
+    await waitFor(() => renderComponentAsUser(<ListPage listId={8} />, 1));
 
     expect(mockGetList).toHaveBeenCalledTimes(1);
     expect(mockGetList).toHaveBeenCalledWith(8);
+  });
+
+  test('should render delete and edit buttons if user created list', async () => {
+    mockGetList.mockResolvedValueOnce(LIST_RESPONSE);
+
+    await waitFor(() => renderComponentAsUser(<ListPage listId={8} />, 2));
+
+    expect(screen.getByText('edit')).toBeInTheDocument();
+    expect(screen.getByText('Delete List')).toBeInTheDocument();
+  });
+
+  test('should not delete or edit buttons if user did not create list', async () => {
+    mockGetList.mockResolvedValueOnce(LIST_RESPONSE);
+
+    await waitFor(() => renderComponentAsUser(<ListPage listId={8} />, 1));
+
+    expect(screen.queryByText('edit')).not.toBeInTheDocument();
+    expect(screen.queryByText('Delete List')).not.toBeInTheDocument();
+  });
+
+  test('edit option links to list edit page', async () => {
+    mockGetList.mockResolvedValueOnce(LIST_RESPONSE);
+    let history;
+
+    await waitFor(() => history = renderComponentAsUser(<ListPage listId={8} />, 2));
+
+    await userEvent.click(screen.getByText('edit'));
+    expect(history.location.pathname).toEqual('/lists/8/edit');
+  });
+
+  test('confirming delete button calls delete list function and redirects to homepage', async () => {
+    mockGetList.mockResolvedValueOnce(LIST_RESPONSE);
+    let history;
+
+    await waitFor(() => history = renderComponentAsUser(<ListPage listId={8} />, 2));
+
+    await userEvent.click(screen.getByText('Delete List'));
+    await userEvent.click(screen.getByText('Delete Forever'));
+
+    expect(mockDeleteList).toHaveBeenCalledTimes(1);
+    expect(mockDeleteList).toHaveBeenCalledWith(8);
+
+    expect(history.location.pathname).toEqual('/');
+  });
+
+  test('calls list favorite function if user clicks favorite control on unfavorited list', async () => {
+    mockGetList.mockResolvedValueOnce({ ...LIST_RESPONSE, hasRaterFavorited: false });
+
+    await waitFor(() => renderComponentAsUser(<ListPage listId={8} />, 2));
+
+    await waitFor(() => userEvent.click(screen.getByText('Favorite List')));
+
+    expect(mockFavoriteList).toHaveBeenCalledTimes(1);
+    expect(mockFavoriteList).toHaveBeenCalledWith(8);
+  });
+
+  test('calls list unfavorite function if user clicks favorite control on favorited list', async () => {
+    mockGetList.mockResolvedValueOnce({ ...LIST_RESPONSE, hasRaterFavorited: true });
+
+    await waitFor(() => renderComponentAsUser(<ListPage listId={8} />, 2));
+
+    await waitFor(() => userEvent.click(screen.getByText('Unfavorite List')));
+
+    expect(mockUnfavoriteList).toHaveBeenCalledTimes(1);
+    expect(mockUnfavoriteList).toHaveBeenCalledWith(8);
   });
 });

--- a/src/components/song/SongDetail.js
+++ b/src/components/song/SongDetail.js
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 
+import { LinkButton, DeleteButton } from '../common';
 import { PlayButton } from '../player/PlayButton';
 
 export const SongDetail = props => {
-  const { song } = props;
+  const { song, canUserModify, onDelete } = props;
 
   const [ songSource, setSongSource ] = useState(song.sources.find(s => s.isPrimary)?.url);
 
@@ -16,14 +17,22 @@ export const SongDetail = props => {
         <span className="text-lg">Avg. Rating: {song.avgRating !== null ? song.avgRating : '--'} / 5</span>
         <span className="text-lg">Year: {song.year}</span>
       </div>
-      <div className="flex items-center">
-        <PlayButton className="text-5xl mx-2" 
-          accessibleName={`Play ${song.name}`}
-          songs={[ songSource ? { ...song, sources: song.sources.filter(s => s.url === songSource) } : song ]} />
-        <select className="p-2" value={songSource} onChange={e => setSongSource(e.target.value)}>
-          <option value="" disabled>Select a source to play...</option>
-          { song.sources.map(s => <option key={s.url} value={s.url}>{s.service}</option>) }
-        </select>
+      <div className="flex flex-col items-end">
+        { canUserModify && (
+          <div className="flex">
+            <LinkButton className="mr-2" to={`/songs/${song.id}/edit`}>edit</LinkButton>
+            <DeleteButton onDelete={onDelete} accessibleName="Delete Song" />
+          </div>
+        )}
+        <div className="flex items-center">
+          <PlayButton className="text-5xl mx-2" 
+            accessibleName={`Play ${song.name}`}
+            songs={[ songSource ? { ...song, sources: song.sources.filter(s => s.url === songSource) } : song ]} />
+          <select className="p-2" value={songSource} onChange={e => setSongSource(e.target.value)}>
+            <option value="" disabled>Select a source to play...</option>
+            { song.sources.map(s => <option key={s.url} value={s.url}>{s.service}</option>) }
+          </select>
+        </div>
       </div>
     </div>
   )

--- a/src/components/song/SongPage.js
+++ b/src/components/song/SongPage.js
@@ -1,7 +1,7 @@
 import React, { useState, useContext } from 'react';
 
 import { api } from '../../api';
-import { useApi, usePagination } from '../../hooks';
+import { useApi, usePagination, useDeleteAndRedirect } from '../../hooks';
 import { UserContext } from '../user/UserProvider';
 import { Page, LoadingIndicator, WarningText, ListSortOptions, PaginationControls } from '../common';
 import { SongDetail } from './SongDetail';
@@ -14,6 +14,8 @@ export const SongPage = props => {
   const { songId } = props;
 
   const { user } = useContext(UserContext);
+
+  const [ handleDelete, deleteError ] = useDeleteAndRedirect(api.songs.delete, songId);
 
   const allRatingSortOptions = [
     { name: 'date', displayName: 'Date' },
@@ -73,8 +75,9 @@ export const SongPage = props => {
     <Page>
       <section>
         <WarningText>{songError}</WarningText>
+        <WarningText>{deleteError}</WarningText>
         <LoadingIndicator isLoading={!song && isSongLoading} />
-        { song && <SongDetail song={song} /> }
+        { song && <SongDetail song={song} onDelete={handleDelete} canUserModify={user?.id === song.creator.id} /> }
         { ratings && <RatingControl value={userRating?.rating} onClick={rateSong} /> }
         { ratings && <ReviewFormToggler rating={userRating} onSubmit={reviewSong} /> }
       </section>

--- a/src/components/song/SongPage.test.js
+++ b/src/components/song/SongPage.test.js
@@ -5,20 +5,67 @@ import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 
 import { UserContext } from '../user/UserProvider';
+import { PlayerContext } from '../player/PlayerProvider';
 import { SongPage } from './SongPage';
 import { api } from '../../api';
 jest.mock('../../api');
 
 const mockGetSong = (api.songs.get = jest.fn());
+const mockDeleteSong = (api.songs.delete = jest.fn());
 const mockListLists = (api.lists.list = jest.fn());
 const mockListRatings = (api.ratings.list = jest.fn());
 
-const renderComponent = ui => {
+const mockSetQueue = jest.fn();
+const mockPlayQueue = jest.fn();
+
+const SONG_RESPONSE = {
+  "id": 2,
+  "name": "Later On",
+  "year": 2014,
+  "artist": {
+      "id": 1,
+      "name": "KoeeoaddiThere",
+      "creator": 2
+  },
+  "genres": [
+      {
+          "id": 2,
+          "genre": {
+              "id": 1,
+              "name": "Indie"
+          }
+      },
+      {
+          "id": 3,
+          "genre": {
+              "id": 8,
+              "name": "Folk"
+          }
+      }
+  ],
+  "sources": [
+      {
+          "id": 2,
+          "url": "https://soundcloud.com/koeeoaddithere/later-on",
+          "service": "Soundcloud",
+          "isPrimary": true,
+          "song": 2
+      }
+  ],
+  "avgRating": null,
+  "creator": {
+      "id": 2,
+  }
+};
+
+const renderComponentAsUser = (ui, userId) => {
   const history = createMemoryHistory();
 
   render(
-    <UserContext.Provider value={{ user: {} }}>
-      <Router history={history}>{ui}</Router>
+    <UserContext.Provider value={{ user: { id: userId } }}>
+      <PlayerContext.Provider value={{ setQueue: mockSetQueue, playQueue: mockPlayQueue }}>
+        <Router history={history}>{ui}</Router>
+      </PlayerContext.Provider>
     </UserContext.Provider>
   );
 
@@ -27,7 +74,7 @@ const renderComponent = ui => {
 
 describe('song page functionality', () => {
   test('gets song data, lists for song, and ratings for song on load', async () => {
-    await waitFor(() => renderComponent(<SongPage songId={2} />));
+    await waitFor(() => renderComponentAsUser(<SongPage songId={2} />, 1));
 
     expect(mockGetSong).toHaveBeenCalledTimes(1);
     expect(mockGetSong).toHaveBeenCalledWith(2);
@@ -35,22 +82,65 @@ describe('song page functionality', () => {
     expect(mockListLists).toHaveBeenCalledTimes(1);
     expect(mockListLists).toHaveBeenCalledWith({ songId: 2, page: 1, pageSize: 10 });
 
-    expect(mockListRatings).toHaveBeenCalledTimes(1);
+    expect(mockListRatings).toHaveBeenCalledTimes(2);
     expect(mockListRatings).toHaveBeenCalledWith({ songId: 2, orderBy: 'date', direction: 'desc', page: 1, pageSize: 10 });
+    expect(mockListRatings).toHaveBeenCalledWith({ songId: 2, userId: 1 });
   });
 
   test('clicking on a rating list sort option will refetch list data', async () => {
-    await waitFor(() => renderComponent(<SongPage songId={2} />));
+    await waitFor(() => renderComponentAsUser(<SongPage songId={2} />, 1));
 
-    expect(mockListRatings).toHaveBeenCalledTimes(1);
+    expect(mockListRatings).toHaveBeenCalledTimes(2);
     expect(mockListRatings).toHaveBeenCalledWith({ songId: 2, orderBy: 'date', direction: 'desc', page: 1, pageSize: 10 });
+    expect(mockListRatings).toHaveBeenCalledWith({ songId: 2, userId: 1 });
 
     const buttons = screen.getAllByRole('button');
     const ratingSortButton = buttons.find(button => button.textContent === 'Rating');
 
     await waitFor(() => userEvent.click(ratingSortButton));
 
-    expect(mockListRatings).toHaveBeenCalledTimes(2);
-    expect(mockListRatings).toHaveBeenCalledWith({ songId: 2, orderBy: 'rating', direction: 'asc', page: 1, pageSize: 10 });
+    expect(mockListRatings).toHaveBeenCalledTimes(3);
+    expect(mockListRatings).toHaveBeenLastCalledWith({ songId: 2, orderBy: 'rating', direction: 'asc', page: 1, pageSize: 10 });
+  });
+
+  test('renders edit and delete controls if user is creator of song', async () => {
+    mockGetSong.mockResolvedValueOnce(SONG_RESPONSE);
+
+    await waitFor(() => renderComponentAsUser(<SongPage songId={2} />, 2));
+
+    expect(screen.getByText('edit')).toBeInTheDocument();
+    expect(screen.getByText('Delete Song')).toBeInTheDocument();
+  });
+
+  test('does not render edit or delete controls if user is not creator of song', async () => {
+    mockGetSong.mockResolvedValueOnce(SONG_RESPONSE);
+
+    await waitFor(() => renderComponentAsUser(<SongPage songId={2} />, 1));
+
+    expect(screen.queryByText('edit')).not.toBeInTheDocument();
+    expect(screen.queryByText('Delete Song')).not.toBeInTheDocument();
+  });
+
+  test('edit links to song edit page', async () => {
+    mockGetSong.mockResolvedValueOnce(SONG_RESPONSE);
+
+    let history;
+    await waitFor(() => history = renderComponentAsUser(<SongPage songId={2} />, 2));
+
+    await userEvent.click(screen.getByText('edit'));
+
+    expect(history.location.pathname).toEqual('/songs/2/edit');
+  });
+
+  test('confirming delete calls song delete function and redirects to /', async () => {
+    mockGetSong.mockResolvedValueOnce(SONG_RESPONSE);
+
+    let history;
+    await waitFor(() => history = renderComponentAsUser(<SongPage songId={2} />, 2));
+
+    await userEvent.click(screen.getByText('Delete Song'));
+    await userEvent.click(screen.getByText('Delete Forever'));
+
+    expect(history.location.pathname).toEqual('/');   
   });
 });

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -3,11 +3,13 @@ import { usePagination } from './usePagination';
 import { useDebounce } from './useDebounce';
 import { useClickOutside } from './useClickOutside';
 import { useClickInside } from './useClickInside';
+import { useDeleteAndRedirect } from './useDeleteAndRedirect';
 
 export {
   useApi,
   usePagination,
   useDebounce,
   useClickOutside,
-  useClickInside
+  useClickInside,
+  useDeleteAndRedirect
 };

--- a/src/hooks/useDeleteAndRedirect.js
+++ b/src/hooks/useDeleteAndRedirect.js
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+import { useHistory } from 'react-router-dom';
+
+export const useDeleteAndRedirect = (deleteFunction, id, redirectTo = '/') => {
+  const history = useHistory();
+
+  const [ error, setError ] = useState('');
+
+  const handleDelete = async () => {
+    try {
+      await deleteFunction(id);
+      history.push(redirectTo);
+    }
+    catch(e) {
+      setError(e.message);
+    }
+  };
+
+  return [ handleDelete, error ];
+};


### PR DESCRIPTION
This PR adds edit and delete controls to the ArtistPage, SongPage, and ListPage, so that if the logged-in user is the person who created the resource they are on the page of, they will be able to navigate to the edit page or delete the resource from the page. To accomplish this a reusable `DeleteButton` component and a `Modal` are added. Also a `useDeleteAndRedirect` custom hook is used. And I wrote a lot more tests for each of those `*Page.js` components.