### PR TITLE
add logic to usePagination to reset page to 1 when some watched varia…

### DIFF
--- a/src/components/artist/ArtistPage.js
+++ b/src/components/artist/ArtistPage.js
@@ -13,7 +13,7 @@ export const ArtistPage = props => {
   const { user } = useContext(UserContext);
 
   const [ orderBy, setOrderBy ] = useState({ orderBy: 'year', direction: 'desc' });
-  const [ paginationParams, paginationFunctions ] = usePagination();
+  const [ paginationParams, paginationFunctions ] = usePagination(orderBy);
   const [ artist, isArtistLoading, artistError ] = useApi(api.artists.get, artistId);
   const [ songsResponse, isSongsLoading, songsError ] = useApi(api.songs.list, { artist: artistId, ...orderBy, ...paginationParams });
 

--- a/src/components/chart/Chart.js
+++ b/src/components/chart/Chart.js
@@ -10,7 +10,7 @@ import { Page, LoadingIndicator, WarningText, PaginationControls } from '../comm
 
 export const Chart = () => {
   const [ chartParams, setChartParams ] = useState({ orderBy: 'avgRating', direction: 'desc' });
-  const [ paginationParams, paginationFunctions ] = usePagination();
+  const [ paginationParams, paginationFunctions ] = usePagination(chartParams);
   const [ songsResponse, isLoading, error ] = useApi(api.songs.list, { ...chartParams, ...paginationParams });
 
   const songs = songsResponse?.data;

--- a/src/components/profile/ProfilePage.js
+++ b/src/components/profile/ProfilePage.js
@@ -17,8 +17,8 @@ export const ProfilePage = props => {
   const [ ratingSortOptions, setRatingSortOptions ] = useState({ orderBy: 'date', direction: 'desc' });
   const [ listSearchParams, setListSearchParams ] = useState({ userId: userId });
 
-  const [ ratingPaginationParams, ratingPaginationFunctions ] = usePagination();
-  const [ listPaginationParams, listPaginationFunctions ] = usePagination();
+  const [ ratingPaginationParams, ratingPaginationFunctions ] = usePagination(ratingSortOptions);
+  const [ listPaginationParams, listPaginationFunctions ] = usePagination(listSearchParams);
 
   const [ user, isUserLoading, userError ] = useApi(api.user.get, userId);
   const [ ratingsResponse, isRatingsLoading, ratingsError ] = useApi(api.ratings.list, { userId: userId, ...ratingSortOptions, ...ratingPaginationParams })

--- a/src/components/song/SongPage.js
+++ b/src/components/song/SongPage.js
@@ -23,7 +23,7 @@ export const SongPage = props => {
   ];
   const [ ratingSortOptions, setRatingSortOptions ] = useState({ orderBy: 'date', direction: 'desc' });
 
-  const [ ratingsPaginationParams, ratingsPaginationFunctions ] = usePagination();
+  const [ ratingsPaginationParams, ratingsPaginationFunctions ] = usePagination(ratingSortOptions);
   const [ listsPaginationParams, listsPaginationFunctions ] = usePagination();
 
   const [ song, isSongLoading, songError, refreshSong ] = useApi(api.songs.get, songId);

--- a/src/hooks/usePagination.js
+++ b/src/hooks/usePagination.js
@@ -1,12 +1,14 @@
 import { useState, useEffect } from 'react';
 
-export const usePagination = (initialPageSize = 10) => {
+export const usePagination = (resetWatchParams, initialPageSize = 10) => {
   const [ page, setPage ] = useState(1);
   const [ pageSize, setPageSize ] = useState(initialPageSize);
 
+  const stringifiedResetWatchParams = JSON.stringify(resetWatchParams);
+
   useEffect(() => {
     setPage(1);
-  }, [ pageSize ]);
+  }, [ pageSize, stringifiedResetWatchParams ]);
 
   const paginationParams = { page, pageSize };
   const paginationFunctions = { 


### PR DESCRIPTION
This PR adds logic to the `usePagination` hook to reset the page to 1 if some watched variable changes that is passed to `usePagination`. This is used to reset lists back to page 1 if the user sorts it differently, adds some filter, etc.