### PR TITLE
do not reset page to 1 in usePagination useEffect, do it manually in …

### DIFF
--- a/src/components/artist/ArtistPage.js
+++ b/src/components/artist/ArtistPage.js
@@ -13,7 +13,7 @@ export const ArtistPage = props => {
   const { user } = useContext(UserContext);
 
   const [ orderBy, setOrderBy ] = useState({ orderBy: 'year', direction: 'desc' });
-  const [ paginationParams, paginationFunctions ] = usePagination(orderBy);
+  const [ paginationParams, paginationFunctions ] = usePagination();
   const [ artist, isArtistLoading, artistError ] = useApi(api.artists.get, artistId);
   const [ songsResponse, isSongsLoading, songsError ] = useApi(api.songs.list, { artist: artistId, ...orderBy, ...paginationParams });
 
@@ -21,6 +21,11 @@ export const ArtistPage = props => {
 
   const songs = songsResponse?.data;
   const songsCount = songsResponse?.count;
+
+  const handleSelectSortOption = sortOption => {
+    setOrderBy(sortOption);
+    paginationFunctions.getPage(1);
+  };
 
   const renderArtistData = () => {
     if(!artist) return null;
@@ -58,7 +63,7 @@ export const ArtistPage = props => {
             songs={songs}
             accessibleName={`Play all ${artist?.name} songs`} />
         </div>
-        <ListSortOptions orderingData={orderBy} fields={songListSortOptions} onSelectSortOption={setOrderBy} />
+        <ListSortOptions orderingData={orderBy} fields={songListSortOptions} onSelectSortOption={handleSelectSortOption} />
       </div>
       <div>
         <SongList songs={songs} />

--- a/src/components/chart/Chart.js
+++ b/src/components/chart/Chart.js
@@ -10,7 +10,7 @@ import { Page, LoadingIndicator, WarningText, PaginationControls } from '../comm
 
 export const Chart = () => {
   const [ chartParams, setChartParams ] = useState({ orderBy: 'avgRating', direction: 'desc' });
-  const [ paginationParams, paginationFunctions ] = usePagination(chartParams);
+  const [ paginationParams, paginationFunctions ] = usePagination();
   const [ songsResponse, isLoading, error ] = useApi(api.songs.list, { ...chartParams, ...paginationParams });
 
   const songs = songsResponse?.data;
@@ -24,6 +24,7 @@ export const Chart = () => {
       else updatedChartParams[name] = value;
       return updatedChartParams;
     });
+    paginationFunctions.getPage(1);
   };
 
   const handleGenreSelect = genres => {
@@ -34,6 +35,7 @@ export const Chart = () => {
       else updatedChartParams.genres = genreIds;
       return updatedChartParams;
     });
+    paginationFunctions.getPage(1);
   };
 
   return (

--- a/src/components/profile/ProfilePage.js
+++ b/src/components/profile/ProfilePage.js
@@ -17,8 +17,8 @@ export const ProfilePage = props => {
   const [ ratingSortOptions, setRatingSortOptions ] = useState({ orderBy: 'date', direction: 'desc' });
   const [ listSearchParams, setListSearchParams ] = useState({ userId: userId });
 
-  const [ ratingPaginationParams, ratingPaginationFunctions ] = usePagination(ratingSortOptions);
-  const [ listPaginationParams, listPaginationFunctions ] = usePagination(listSearchParams);
+  const [ ratingPaginationParams, ratingPaginationFunctions ] = usePagination();
+  const [ listPaginationParams, listPaginationFunctions ] = usePagination();
 
   const [ user, isUserLoading, userError ] = useApi(api.user.get, userId);
   const [ ratingsResponse, isRatingsLoading, ratingsError ] = useApi(api.ratings.list, { userId: userId, ...ratingSortOptions, ...ratingPaginationParams })
@@ -34,6 +34,13 @@ export const ProfilePage = props => {
     const { name } = e.target;
     if(name === 'userId') setListSearchParams({ userId });
     else if(name === 'favoritedBy') setListSearchParams({ favoritedBy: userId });
+
+    listPaginationFunctions.getPage(1);
+  };
+
+  const handleRatingSort = sortOptions => {
+    setRatingSortOptions(sortOptions);
+    ratingPaginationFunctions.getPage(1);
   };
 
   return (
@@ -61,7 +68,7 @@ export const ProfilePage = props => {
           </div>
           <ListSortOptions fields={allRatingSortOptions} 
             orderingData={ratingSortOptions}
-            onSelectSortOption={setRatingSortOptions} />
+            onSelectSortOption={handleRatingSort} />
         </div>
 
         { ratings && 

--- a/src/components/song/SongPage.js
+++ b/src/components/song/SongPage.js
@@ -23,7 +23,7 @@ export const SongPage = props => {
   ];
   const [ ratingSortOptions, setRatingSortOptions ] = useState({ orderBy: 'date', direction: 'desc' });
 
-  const [ ratingsPaginationParams, ratingsPaginationFunctions ] = usePagination(ratingSortOptions);
+  const [ ratingsPaginationParams, ratingsPaginationFunctions ] = usePagination();
   const [ listsPaginationParams, listsPaginationFunctions ] = usePagination();
 
   const [ song, isSongLoading, songError, refreshSong ] = useApi(api.songs.get, songId);
@@ -71,6 +71,11 @@ export const SongPage = props => {
     refreshUserRating();
   };
 
+  const handleRatingSort = sortOptions => {
+    setRatingSortOptions(sortOptions);
+    ratingsPaginationFunctions.getPage(1);
+  };
+
   return (
     <Page>
       <section>
@@ -95,7 +100,7 @@ export const SongPage = props => {
           <h3 className="text-2xl">Ratings and Reviews</h3>
           <ListSortOptions fields={allRatingSortOptions} 
             orderingData={ratingSortOptions} 
-            onSelectSortOption={setRatingSortOptions} />
+            onSelectSortOption={handleRatingSort} />
         </div>
         { ratings && 
         <div>

--- a/src/hooks/usePagination.js
+++ b/src/hooks/usePagination.js
@@ -1,14 +1,12 @@
 import { useState, useEffect } from 'react';
 
-export const usePagination = (resetWatchParams, initialPageSize = 10) => {
+export const usePagination = (initialPageSize = 10) => {
   const [ page, setPage ] = useState(1);
   const [ pageSize, setPageSize ] = useState(initialPageSize);
 
-  const stringifiedResetWatchParams = JSON.stringify(resetWatchParams);
-
   useEffect(() => {
     setPage(1);
-  }, [ pageSize, stringifiedResetWatchParams ]);
+  }, [ pageSize ]);
 
   const paginationParams = { page, pageSize };
   const paginationFunctions = { 


### PR DESCRIPTION
In my last PR I implemented a feature where usePagination would reset its page state varible to 1 if some watched variable(s) changed. This was causing double fetches that I did not notice though, since some variable could change that would trigger an API fetch in useApi, and then trigger a page update in the useEffect I added in usePagination, and then consequently trigger another API fetch in useApi. So, I reimplemented resetting of page to 1 directly in all components that use the combination of pagination + sorting/filtering, and it is done in the handling code for the user selecting a different sort option/filter option.