### PR TITLE
implement queue component and tests

### DIFF
--- a/src/components/player/PlayerContainer.js
+++ b/src/components/player/PlayerContainer.js
@@ -1,12 +1,18 @@
-import React, { useEffect, useState, useContext } from 'react';
-import { MdExpandLess } from 'react-icons/md';
+import React, { useEffect, useState, useContext, useCallback } from 'react';
+import { MdExpandLess, MdQueueMusic } from 'react-icons/md';
 
 import { PlayerControls } from './PlayerControls';
 import { PlayerContext } from './PlayerProvider';
 import { Player } from './Player';
+import { Queue } from './Queue';
+import { RemoveButton } from '../common';
+import { useDebounce } from '../../hooks';
 
 export const PlayerContainer = () => {
   const [ isExpanded, setIsExpanded ] = useState(false);
+  const [ isQueueShowing, setIsQueueShowing ] = useState(false);
+
+  const debouncedIsQueueShowing = useDebounce(isQueueShowing, 150);
 
   const { isPlaying, queue } = useContext(PlayerContext);
 
@@ -21,12 +27,38 @@ export const PlayerContainer = () => {
     if(isPlaying && queue) setIsExpanded(true);
   }, [ isPlaying, queue ]);
 
-  return (
+  const handleEscape = useCallback(e => {
+    if(e.key === 'Escape') {
+      setIsQueueShowing(false);  
+    }
+  }, [ setIsQueueShowing ]);
+
+  useEffect(() => {
+    if(isQueueShowing) {
+      document.addEventListener('keydown', handleEscape);
+
+      return () => document.removeEventListener('keydown', handleEscape);
+    }
+  }, [ isQueueShowing ]);
+
+  return <>
     <div style={{ height: isExpanded ? '10rem' : '5rem' }}
       className={`w-full fixed z-10 bottom-0 bg-gray-100 px-2 py-4 border-t border-gray-200 transition-all flex flex-col ${isExpanded ? 'justify-between' : 'justify-center'}`}
     >
       <div className="flex items-center justify-between relative">
-        <h2 className="text-2xl text-center absolute left-1/2 transform -translate-x-1/2"><span className="text-emerald">RMM</span> Player</h2>
+        <button onClick={() => setIsQueueShowing(prevIsQueueShowing => !prevIsQueueShowing)}
+          className={`text-3xl hover:bg-gray-200 mr-auto ${isQueueShowing ? 'text-deepred' : 'text-black'}`}>
+            <span className="sr-only">{isQueueShowing ? 'Hide Queue' : 'Show Queue'}</span>
+            <MdQueueMusic />
+        </button>
+
+        <div className="absolute left-1/2 transform -translate-x-1/2">
+          <button className="absolute top-0 left-0 w-full h-full" onClick={() => setIsExpanded(prevExpanded => !prevExpanded)}>
+            <span className="sr-only">{isExpanded ? "Collapse Player" : "Expand Player" }</span>
+          </button>
+          <h2 className="text-2xl text-center"><span className="text-emerald">RMM</span> Player</h2>
+        </div>
+
         <button onClick={() => setIsExpanded(prevExpanded => !prevExpanded)} 
           className="text-3xl hover:bg-gray-200 ml-auto"
         >
@@ -34,8 +66,17 @@ export const PlayerContainer = () => {
           <span className="sr-only">{isExpanded ? "Collapse Player" : "Expand Player" }</span>
         </button>
       </div>
+
       { isExpanded && <PlayerControls /> }
       <Player />
     </div>
-  );
+
+    <div style={{ height: `calc(100vh - ${isExpanded ? '10rem' : '5rem' })`}} 
+      className={`fixed top-0 left-0 overflow-scroll bg-lightyellow bg-opacity-80 transform transition-all w-56 px-2 py-4 ${isQueueShowing ? 'translate-x-0' : '-translate-x-full'}`}>
+        { (isQueueShowing || debouncedIsQueueShowing) && <>
+          <RemoveButton className="ml-auto" accessibleName="Hide Queue" onClick={() => setIsQueueShowing(false)} />
+          <Queue />
+        </> }
+    </div>
+  </>;
 };

--- a/src/components/player/PlayerContainer.test.js
+++ b/src/components/player/PlayerContainer.test.js
@@ -6,7 +6,7 @@ import { PlayerContainer } from './PlayerContainer';
 import { PlayerContext } from './PlayerProvider';
 
 const renderComponent = (ui, isPlaying = false) => {
-  render(
+  return render(
     <PlayerContext.Provider value={{ isPlaying }}>
       {ui}
     </PlayerContext.Provider>
@@ -17,13 +17,13 @@ describe('player expander functionality', () => {
   test('displays collapsed by default', () => {
     renderComponent(<PlayerContainer />);
     
-    expect(screen.getByText('Expand Player')).toBeInTheDocument();
+    expect(screen.getAllByText('Expand Player')).toHaveLength(2);
   });
 
-  test('user can expand or collapse the player with the button', () => {
+  test('user can expand or collapse the player with the RMM Player text button', () => {
     renderComponent(<PlayerContainer />);
 
-    const button = screen.getByRole('button');
+    const button = screen.getAllByRole('button')[1];
     expect(button).toHaveTextContent('Expand Player');
 
     userEvent.click(button);
@@ -31,5 +31,65 @@ describe('player expander functionality', () => {
 
     userEvent.click(button);
     expect(button).toHaveTextContent('Expand Player');
+  });
+
+  test('user can expand or collapse the player with the arrow button', () => {
+    renderComponent(<PlayerContainer />);
+
+    const button = screen.getAllByRole('button')[2];
+    expect(button).toHaveTextContent('Expand Player');
+
+    userEvent.click(button);
+    expect(button).toHaveTextContent('Collapse Player');
+
+    userEvent.click(button);
+    expect(button).toHaveTextContent('Expand Player');
+  });
+
+  test('user can expand or collapse the queue with the queue button', () => {
+    renderComponent(<PlayerContainer />);
+
+    const button = screen.getAllByRole('button')[0];
+    expect(button).toHaveTextContent('Show Queue');
+
+    userEvent.click(button);
+    expect(button).toHaveTextContent('Hide Queue');
+
+    userEvent.click(button);
+    expect(button).toHaveTextContent('Show Queue');
+  });
+
+  test('user can close queue with the close button rendered within the queue wrapper', () => {
+    renderComponent(<PlayerContainer />);
+
+    const button = screen.getAllByRole('button')[0];
+    expect(button).toHaveTextContent('Show Queue');
+
+    userEvent.click(button);
+
+    const queueCloseButton = screen.getAllByRole('button')[3];
+    expect(button).toHaveTextContent('Hide Queue');
+    expect(queueCloseButton).toBeInTheDocument();
+    expect(queueCloseButton).toHaveTextContent('Hide Queue');
+
+    userEvent.click(queueCloseButton);
+
+    expect(queueCloseButton).not.toBeInTheDocument();
+
+    expect(button).toHaveTextContent('Show Queue');
+  });
+
+  test('user can close queue with escape key', () => {
+    const { container } = renderComponent(<PlayerContainer />);
+
+    const button = screen.getAllByRole('button')[0];
+    expect(button).toHaveTextContent('Show Queue');
+
+    userEvent.click(button);
+    expect(button).toHaveTextContent('Hide Queue');
+
+    userEvent.type(container, '{esc}');
+
+    expect(button).toHaveTextContent('Show Queue');
   });
 });

--- a/src/components/player/PlayerControls.js
+++ b/src/components/player/PlayerControls.js
@@ -13,13 +13,13 @@ export const PlayerControls = () => {
   }
 
   const playButton = (
-    <PlayerControl onClick={play} accessibleName={`Play ${currentSong.name}`}>
+    <PlayerControl onClick={() => play()} accessibleName={`Play ${currentSong.name}`}>
       <MdPlayArrow />
     </PlayerControl>
   );
 
   const pauseButton = (
-    <PlayerControl onClick={pause} accessibleName={`Pause ${currentSong.name}`}>
+    <PlayerControl onClick={() => pause()} accessibleName={`Pause ${currentSong.name}`}>
       <MdPause />
     </PlayerControl>
   );

--- a/src/components/player/PlayerProvider.js
+++ b/src/components/player/PlayerProvider.js
@@ -55,7 +55,8 @@ export const PlayerProvider = props => {
     setPlayIndex(0);
   }
 
-  const play = () => {
+  const play = idx => {
+    if(idx !== undefined) setPlayIndex(idx);
     setIsPlaying(true);
   };
 

--- a/src/components/player/Queue.js
+++ b/src/components/player/Queue.js
@@ -1,0 +1,29 @@
+import React, { useContext } from 'react';
+
+import { PlayerContext } from './PlayerProvider';
+
+export const Queue = () => {
+  const { queue, play, currentSong } = useContext(PlayerContext);
+
+  if(!queue?.length) {
+    return <p className="italic">You have no songs queued.</p>;
+  }
+
+  return (
+    <div>
+      <h3 className="text-2xl text-center">Your Queue</h3>
+      <ul>
+        { queue.map((song, idx) => (
+          <li key={song.id}
+            className={`relative flex flex-col items-center justify-center text-center my-2 rounded hover:bg-lightyellow-dark ${song.id === currentSong.id ? 'text-deepred-dark font-bold animate-pulse' : ''}`}>
+            <button className="absolute top-0 left-0 w-full h-full" onClick={() => play(idx)}>
+              <span className="sr-only">Play Song in Queue</span>
+            </button>
+            <span className="text-lg">{song.name}</span>
+            <span>{song.artist.name}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+};

--- a/src/components/player/Queue.test.js
+++ b/src/components/player/Queue.test.js
@@ -1,0 +1,104 @@
+import React from 'react';
+import { render, screen, getByText, getByRole } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Queue } from './Queue';
+import { PlayerContext } from '../player/PlayerProvider';
+
+const mockPlay = jest.fn();
+
+const renderComponent = (ui, queue, currentSong) => {
+  render(
+    <PlayerContext.Provider value={{ 
+      queue, 
+      play: mockPlay,
+      currentSong: currentSong || queue[0]
+    }}>{ui}</PlayerContext.Provider>
+  );
+};
+
+const TEST_QUEUE = [
+  {
+    id: 1,
+    name: 'Save a Secret for the Moon',
+    artist: {
+      id: 1,
+      name: 'The Magnetic Fields'
+    },
+    sources: [
+      {
+        service: 'YouTube',
+        url: 'http://www.youtube.com/1234',
+        isPrimary: true
+      }
+    ]
+  },
+  {
+    id: 2,
+    name: 'Aquarius',
+    artist: {
+      id: 2,
+      name: 'Boards of Canada'
+    },
+    sources: [
+      {
+        service: 'YouTube',
+        url: 'http://www.youtube.com/5678',
+        isPrimary: true
+      }
+    ]
+  }
+];
+
+describe('queue functionality', () => {
+  test('should render song and artist name within listitems for each song in queue', () => {
+    renderComponent(<Queue />, TEST_QUEUE);
+
+    expect(screen.getByRole('list')).toBeInTheDocument();
+
+    const listItems = screen.getAllByRole('listitem');
+    expect(listItems).toHaveLength(2);
+
+    expect(getByText(listItems[0], 'Save a Secret for the Moon')).toBeInTheDocument();
+    expect(getByText(listItems[0], 'The Magnetic Fields')).toBeInTheDocument();
+
+    expect(getByText(listItems[1], 'Aquarius')).toBeInTheDocument();
+    expect(getByText(listItems[1], 'Boards of Canada')).toBeInTheDocument();
+  });
+
+  test('clicking on a list item should play the song with corresponding index in the queue', () => {
+    renderComponent(<Queue />, TEST_QUEUE);
+
+    const aqariusListItem = screen.getAllByRole('listitem')[1];
+    userEvent.click(getByRole(aqariusListItem, 'button'));
+
+    expect(mockPlay).toHaveBeenCalledTimes(1);
+    expect(mockPlay).toHaveBeenCalledWith(1);
+  });
+
+  test('song currently playing in queue is styled with deepred-dark text, bold font, and pulse animation', () => {
+    renderComponent(<Queue />, TEST_QUEUE, TEST_QUEUE[0]);
+
+    const playingListItem = screen.getAllByRole('listitem')[0];
+    const classListArray = [ ...playingListItem.classList ];
+    expect(classListArray).toContain('text-deepred-dark');
+    expect(classListArray).toContain('font-bold');
+    expect(classListArray).toContain('animate-pulse');
+  });
+
+  test('song not currently playing in queue is not styled with deepred-dark text, bold font, nor pulse animation', () => {
+    renderComponent(<Queue />, TEST_QUEUE, TEST_QUEUE[0]);
+
+    const notPlayingListItem = screen.getAllByRole('listitem')[1];
+    const classListArray = [ ...notPlayingListItem.classList ];
+    expect(classListArray).not.toContain('text-deepred-dark');
+    expect(classListArray).not.toContain('font-bold');
+    expect(classListArray).not.toContain('animate-pulse');
+  });
+
+  test('if queue is empty renders no songs queued message', () => {
+    renderComponent(<Queue />, []);
+
+    expect(screen.getByText('You have no songs queued.')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
This PR adds a new Queue component that lets the user view what is currently in their queue, see what song is playing at what position in the queue, and start playing their current queue from any arbitrary point in the queue. It also adds tests for these features. And I also did it all on one monolithic commit lol whoops I got carried away okay sorry.