### PR TITLE
Player seek control

### DIFF
--- a/src/components/artist/ArtistPage.test.js
+++ b/src/components/artist/ArtistPage.test.js
@@ -14,15 +14,14 @@ const mockGetArtist = (api.artists.get = jest.fn());
 const mockDeleteArtist = (api.artists.delete = jest.fn());
 const mockListSongs = (api.songs.list = jest.fn());
 
-const mockSetQueue = jest.fn();
-const mockPlay = jest.fn();
+const mockUpdateQueue = jest.fn();
 
 const renderComponentAsUser = (ui, userId) => {
   const history = createMemoryHistory();
 
   render(
     <UserContext.Provider value={{ user: { id: userId }}}>
-      <PlayerContext.Provider value={{ setQueue: mockSetQueue, play: mockPlay }}>
+      <PlayerContext.Provider value={{ updateQueue: mockUpdateQueue }}>
         <Router history={history}>
           {ui}
         </Router>
@@ -124,11 +123,8 @@ describe('artist page functionality', () => {
     const playButton = await screen.findByText('Play all Chuck Person songs');
     userEvent.click(playButton);
 
-    expect(mockSetQueue).toHaveBeenCalledTimes(1);
-    expect(mockSetQueue).toHaveBeenCalledWith(songsResponse.data);
-
-    expect(mockPlay).toHaveBeenCalledTimes(1);
-    expect(mockPlay).toHaveBeenCalledWith(0);
+    expect(mockUpdateQueue).toHaveBeenCalledTimes(1);
+    expect(mockUpdateQueue).toHaveBeenCalledWith(songsResponse.data);
   });
 
   test('renders edit and delete controls when user is creator of artist', async () => {

--- a/src/components/chart/Chart.test.js
+++ b/src/components/chart/Chart.test.js
@@ -13,15 +13,14 @@ jest.mock('../../api');
 const mockListSongs = (api.songs.list = jest.fn());
 const mockSearchGenres = (api.genres.search = jest.fn());
 const mockListGenres = (api.genres.list = jest.fn());
-const mockSetQueue = jest.fn();
-const mockPlay = jest.fn();
+const mockUpdateQueue = jest.fn();
 
 const renderComponent = (ui, url = '/charts') => {
   const history = createMemoryHistory();
   history.push(url);
 
   render(
-    <PlayerContext.Provider value={{ setQueue: mockSetQueue, play: mockPlay }}>
+    <PlayerContext.Provider value={{ updateQueue: mockUpdateQueue }}>
       <Router history={history}>
         {ui}
       </Router>
@@ -167,11 +166,8 @@ describe('chart functionality', () => {
     await waitFor(() => expect(mockListSongs).toHaveBeenCalledTimes(1));
     await waitFor(() => userEvent.click(screen.getByText('Play All Songs in Chart')));
 
-    expect(mockSetQueue).toHaveBeenCalledTimes(1);
-    expect(mockSetQueue).toHaveBeenLastCalledWith(SONGS_RESPONSE.data);
-    
-    expect(mockPlay).toHaveBeenCalledTimes(1);
-    expect(mockPlay).toHaveBeenCalledWith(0);
+    expect(mockUpdateQueue).toHaveBeenCalledTimes(1);
+    expect(mockUpdateQueue).toHaveBeenLastCalledWith(SONGS_RESPONSE.data);
   });
 
   test('initializes startYear value from query string parameter', async () => {

--- a/src/components/list/ListDetail.test.js
+++ b/src/components/list/ListDetail.test.js
@@ -7,14 +7,13 @@ import { createMemoryHistory } from 'history';
 import { ListDetail } from './ListDetail';
 import { PlayerContext } from '../player/PlayerProvider';
 
-const mockSetQueue = jest.fn();
-const mockPlay = jest.fn();
+const mockUpdateQueue = jest.fn();
 
 const renderComponent = ui => {
   const history = createMemoryHistory();
 
   render(
-    <PlayerContext.Provider value={{ setQueue: mockSetQueue, play: mockPlay }}>
+    <PlayerContext.Provider value={{ updateQueue: mockUpdateQueue }}>
       <Router history={history}>{ui}</Router>
     </PlayerContext.Provider>
   );
@@ -111,8 +110,8 @@ describe('list detail functionality', () => {
 
     userEvent.click(screen.getByText('Play all songs in list "My favorite songs"'));
 
-    expect(mockSetQueue).toHaveBeenCalledTimes(1);
-    expect(mockSetQueue).toHaveBeenCalledWith([
+    expect(mockUpdateQueue).toHaveBeenCalledTimes(1);
+    expect(mockUpdateQueue).toHaveBeenCalledWith([
       {
         "id": 1,
         "name": "Half-Life",
@@ -157,8 +156,5 @@ describe('list detail functionality', () => {
         ]
       }
     ]);
-
-    expect(mockPlay).toHaveBeenCalledTimes(1);
-    expect(mockPlay).toHaveBeenCalledWith(0);
   });
 });

--- a/src/components/player/Duration.js
+++ b/src/components/player/Duration.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { convertSecondsToTimeString } from '../../utils';
+
+export const Duration = props => {
+  const { seconds, className } = props;
+
+  return (
+    <span className={className}>
+      { seconds !== null ? convertSecondsToTimeString(Math.floor(seconds)) : '--' }
+    </span>
+  );
+};

--- a/src/components/player/Duration.js
+++ b/src/components/player/Duration.js
@@ -7,7 +7,7 @@ export const Duration = props => {
 
   return (
     <span className={className}>
-      { seconds !== null ? convertSecondsToTimeString(Math.floor(seconds)) : '--' }
+      { seconds !== null && !isNaN(seconds) ? convertSecondsToTimeString(Math.floor(seconds)) : '--' }
     </span>
   );
 };

--- a/src/components/player/Duration.test.js
+++ b/src/components/player/Duration.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { Duration } from './Duration';
+
+describe('duration functionality', () => {
+  test('displays seconds value converted to time string if non-null value supplied', () => {
+    render(<Duration seconds={312} />);
+
+    expect(screen.getByText('5:12')).toBeInTheDocument();
+  });
+
+  test('displays -- if null value passed in', () => {
+    render(<Duration seconds={null} />);
+
+    expect(screen.getByText('--')).toBeInTheDocument();
+  });
+});

--- a/src/components/player/PlayButton.js
+++ b/src/components/player/PlayButton.js
@@ -5,15 +5,10 @@ import { PlayerContext } from './PlayerProvider';
 
 export const PlayButton = props => {
   const { songs, className, accessibleName } = props;
-  const { setQueue, play } = useContext(PlayerContext);
-
-  const handleClick = () => {
-    setQueue([ ...songs ]);
-    play(0);
-  }
+  const { updateQueue } = useContext(PlayerContext);
 
   return (
-    <button onClick={handleClick}
+    <button onClick={() => updateQueue([ ...songs ])}
       className={`bg-transparent hover:text-deepred ${className || ''}`}>
         <MdPlayCircleFilled />
         <span className="sr-only">{accessibleName || "Play Songs"}</span>

--- a/src/components/player/PlayButton.test.js
+++ b/src/components/player/PlayButton.test.js
@@ -5,12 +5,11 @@ import userEvent from '@testing-library/user-event';
 import { PlayButton } from './PlayButton';
 import { PlayerContext } from './PlayerProvider';
 
-const mockSetQueue = jest.fn();
-const mockPlay = jest.fn();
+const mockUpdateQueue = jest.fn();
 
 const renderComponent = ui => {
   render(
-    <PlayerContext.Provider value={{ setQueue: mockSetQueue, play: mockPlay }}>
+    <PlayerContext.Provider value={{ updateQueue: mockUpdateQueue }}>
       { ui }
     </PlayerContext.Provider>
   );
@@ -26,9 +25,7 @@ describe('play button functionality', () => {
     expect(screen.getByRole('button')).toBeInTheDocument();
 
     userEvent.click(screen.getByText('Play All Magnetic Fields Songs'));
-    expect(mockSetQueue).toHaveBeenCalledTimes(1);
-    expect(mockSetQueue).toHaveBeenLastCalledWith([ { id: 1, name: 'Save a Secret for the Moon' } ]);
-    expect(mockPlay).toHaveBeenCalledTimes(1);
-    expect(mockPlay).toHaveBeenCalledWith(0);
+    expect(mockUpdateQueue).toHaveBeenCalledTimes(1);
+    expect(mockUpdateQueue).toHaveBeenLastCalledWith([ { id: 1, name: 'Save a Secret for the Moon' } ]);
   });
 });

--- a/src/components/player/Player.js
+++ b/src/components/player/Player.js
@@ -14,6 +14,12 @@ export const Player = () => {
     }
   }, [ playerRef, setPlayerRef ]);
 
+  const handleProgress = progress => {
+    if(isPlaying) {
+      setElapsed(progress.played);
+    }
+  };
+
   return (
     <div className="w-0 h-0">
       <ReactPlayer width={0} height={0}
@@ -22,7 +28,7 @@ export const Player = () => {
         onPause={() => setIsPlaying(false)}
         onPlay={() => setIsPlaying(true)}
         onDuration={duration => setDuration(duration)}
-        onProgress={progress => setElapsed(progress.played)}
+        onProgress={handleProgress}
         url={currentSongUrl}
         playing={isPlaying} />
     </div>

--- a/src/components/player/Player.js
+++ b/src/components/player/Player.js
@@ -1,17 +1,28 @@
-import React, { useContext } from 'react';
+import React, { useContext, useRef, useEffect } from 'react';
 import ReactPlayer from 'react-player';
 
 import { PlayerContext } from './PlayerProvider';
 
 export const Player = () => {
-  const { setIsPlaying, isPlaying, currentSongUrl, skip } = useContext(PlayerContext);
+  const { setIsPlaying, isPlaying, currentSongUrl, skip, setDuration, setElapsed, setPlayerRef } = useContext(PlayerContext);
+
+  const playerRef = useRef(null);
+
+  useEffect(() => {
+    if(playerRef) {
+      setPlayerRef(playerRef);
+    }
+  }, [ playerRef, setPlayerRef ]);
 
   return (
     <div className="w-0 h-0">
       <ReactPlayer width={0} height={0}
+        ref={playerRef}
         onEnded={() => skip(1)}
         onPause={() => setIsPlaying(false)}
         onPlay={() => setIsPlaying(true)}
+        onDuration={duration => setDuration(duration)}
+        onProgress={progress => setElapsed(progress.played)}
         url={currentSongUrl}
         playing={isPlaying} />
     </div>

--- a/src/components/player/PlayerContainer.js
+++ b/src/components/player/PlayerContainer.js
@@ -17,7 +17,7 @@ export const PlayerContainer = () => {
   const { isPlaying, queue } = useContext(PlayerContext);
 
   useEffect(() => {
-    if(isExpanded) document.body.style = 'margin-bottom: 10rem;';
+    if(isExpanded) document.body.style = 'margin-bottom: 12rem;';
     else document.body.style = 'margin-bottom: 5rem;';
 
     return () => document.body.style = 'margin-bottom: 0';
@@ -42,7 +42,7 @@ export const PlayerContainer = () => {
   }, [ isQueueShowing, handleEscape ]);
 
   return <>
-    <div style={{ height: isExpanded ? '10rem' : '5rem' }}
+    <div style={{ height: isExpanded ? '12rem' : '5rem' }}
       className={`w-full fixed z-10 bottom-0 bg-gray-100 px-2 py-4 border-t border-gray-200 transition-all flex flex-col ${isExpanded ? 'justify-between' : 'justify-center'}`}
     >
       <div className="flex items-center justify-between relative">
@@ -71,7 +71,7 @@ export const PlayerContainer = () => {
       <Player />
     </div>
 
-    <div style={{ height: `calc(100vh - ${isExpanded ? '10rem' : '5rem' })`}} 
+    <div style={{ height: `calc(100vh - ${isExpanded ? '12rem' : '5rem' })`}} 
       className={`fixed top-0 left-0 overflow-scroll bg-lightyellow bg-opacity-80 transform transition-all w-56 px-2 py-4 ${isQueueShowing ? 'translate-x-0' : '-translate-x-full'}`}>
         { (isQueueShowing || debouncedIsQueueShowing) && <>
           <RemoveButton className="ml-auto" accessibleName="Hide Queue" onClick={() => setIsQueueShowing(false)} />

--- a/src/components/player/PlayerContainer.test.js
+++ b/src/components/player/PlayerContainer.test.js
@@ -5,9 +5,11 @@ import userEvent from '@testing-library/user-event';
 import { PlayerContainer } from './PlayerContainer';
 import { PlayerContext } from './PlayerProvider';
 
+const mockSetPlayerRef = jest.fn();
+
 const renderComponent = (ui, isPlaying = false) => {
   return render(
-    <PlayerContext.Provider value={{ isPlaying }}>
+    <PlayerContext.Provider value={{ isPlaying, setPlayerRef: mockSetPlayerRef }}>
       {ui}
     </PlayerContext.Provider>
   );

--- a/src/components/player/PlayerControls.js
+++ b/src/components/player/PlayerControls.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 
 import { PlayerContext } from './PlayerProvider';
 import { PlayerControl } from './PlayerControl';
+import { PlayerSeekControl } from './PlayerSeekControl';
 
 export const PlayerControls = () => {
   const { play, pause, skip, isPlaying, currentSong } = useContext(PlayerContext);
@@ -45,6 +46,10 @@ export const PlayerControls = () => {
         <PlayerControl onClick={() => skip(1)} accessibleName="Next Song">
           <MdSkipNext />
         </PlayerControl>
+      </div>
+
+      <div>
+        <PlayerSeekControl />
       </div>
     </div>
   );

--- a/src/components/player/PlayerProvider.js
+++ b/src/components/player/PlayerProvider.js
@@ -22,6 +22,9 @@ export const PlayerProvider = props => {
   const [ queue, setQueue ] = useState([]);
   const [ playIndex, setPlayIndex ] = useState(0);
   const [ isPlaying, setIsPlaying ] = useState(null);
+  const [ duration, setDuration ] = useState(null);
+  const [ elapsed, setElapsed ] = useState(null);
+  const [ playerRef, setPlayerRef ] = useState(null);
 
   const { user } = useContext(UserContext);
 
@@ -60,6 +63,8 @@ export const PlayerProvider = props => {
   };
 
   const skip = increment => {
+    setDuration(null);
+    setElapsed(null);
     setPlayIndex(prevPlayIndex => (prevPlayIndex + increment) % queue.length);
   };
 
@@ -69,7 +74,8 @@ export const PlayerProvider = props => {
 
   return (
     <PlayerContext.Provider value={{
-      queue, setQueue, play, pause, skip, setIsPlaying, isPlaying, currentSong, currentSongUrl
+      queue, setQueue, play, pause, skip, setIsPlaying, isPlaying, currentSong, currentSongUrl,
+      duration, setDuration, elapsed, setElapsed, playerRef, setPlayerRef
     }}>
       { props.children }
     </PlayerContext.Provider>

--- a/src/components/player/PlayerProvider.js
+++ b/src/components/player/PlayerProvider.js
@@ -67,7 +67,11 @@ export const PlayerProvider = props => {
   };
 
   const skip = increment => {
-    updatePlayIndex(prevPlayIndex => (prevPlayIndex + increment) % queue.length);
+    updatePlayIndex(prevPlayIndex => {
+      let nextIndex = prevPlayIndex + increment;
+      if(nextIndex < 0) nextIndex = queue.length - 1;
+      return nextIndex % queue.length;
+    });
   };
 
   const updatePlayIndex = idx => {
@@ -75,7 +79,6 @@ export const PlayerProvider = props => {
       setDuration(null);
       setElapsed(null);
     }
-
     setPlayIndex(idx);
   };
 

--- a/src/components/player/PlayerProvider.js
+++ b/src/components/player/PlayerProvider.js
@@ -53,8 +53,12 @@ export const PlayerProvider = props => {
     }
   }, [ user, playIndex, queue ]);
 
-  const play = idx => {
-    if(idx !== undefined) setPlayIndex(idx);
+  const currentSong = queue[playIndex];
+
+  const currentSongUrl = queue[playIndex]?.sources.find(source => source.isPrimary)?.url || queue[playIndex]?.sources[0]?.url;
+
+  const play = (idx = playIndex) => {
+    updatePlayIndex(idx);
     setIsPlaying(true);
   };
 
@@ -63,18 +67,31 @@ export const PlayerProvider = props => {
   };
 
   const skip = increment => {
-    setDuration(null);
-    setElapsed(null);
-    setPlayIndex(prevPlayIndex => (prevPlayIndex + increment) % queue.length);
+    updatePlayIndex(prevPlayIndex => (prevPlayIndex + increment) % queue.length);
   };
 
-  const currentSong = queue[playIndex];
+  const updatePlayIndex = idx => {
+    if(playIndex !== idx) {
+      setDuration(null);
+      setElapsed(null);
+    }
 
-  const currentSongUrl = queue[playIndex]?.sources.find(source => source.isPrimary)?.url || queue[playIndex]?.sources[0]?.url;
+    setPlayIndex(idx);
+  };
+
+  const updateQueue = songs => {
+    if(!currentSong || songs[0]?.id !== currentSong.id) {
+      setDuration(null);
+      setElapsed(null);
+    }
+    setQueue(songs);
+    setPlayIndex(0);
+    setIsPlaying(true);
+  };
 
   return (
     <PlayerContext.Provider value={{
-      queue, setQueue, play, pause, skip, setIsPlaying, isPlaying, currentSong, currentSongUrl,
+      queue, updateQueue, play, pause, skip, setIsPlaying, isPlaying, currentSong, currentSongUrl,
       duration, setDuration, elapsed, setElapsed, playerRef, setPlayerRef
     }}>
       { props.children }

--- a/src/components/player/PlayerSeekControl.js
+++ b/src/components/player/PlayerSeekControl.js
@@ -1,0 +1,41 @@
+import React, { useState, useContext, useEffect } from 'react';
+
+import { PlayerContext } from './PlayerProvider';
+import { Duration } from './Duration';
+
+export const PlayerSeekControl = () => {
+  const [ isSeeking, setIsSeeking ] = useState(false);
+  const { elapsed, duration, playerRef } = useContext(PlayerContext);
+  const [ seekLocation, setSeekLocation ] = useState(elapsed);
+
+  useEffect(() => {
+    if(!isSeeking) {
+      setSeekLocation(elapsed);
+    }
+  }, [ elapsed ]);
+
+  const stepSize = 1 / duration;
+
+  const handleSeek = e => {
+    const seekPercent = parseFloat(e.target.value);
+    setSeekLocation(seekPercent);
+  };
+
+  const handleMouseUp = () => {
+    setIsSeeking(false);
+    playerRef.current.seekTo(seekLocation, 'fraction');
+  };
+
+  return (
+    <div className="flex justify-center items-center">
+      <Duration className="w-24 text-right" seconds={duration ? seekLocation * duration : 0} />
+      <input type="range" min={0} max={1} step={stepSize}
+        className="mx-2 flex-shrink-0"
+        value={seekLocation || 0}
+        onMouseDown={() => setIsSeeking(true)}
+        onChange={handleSeek}
+        onMouseUp={handleMouseUp} />
+      <Duration className="w-24 text-left" seconds={duration} />
+    </div>
+  );
+};

--- a/src/components/player/PlayerSeekControl.js
+++ b/src/components/player/PlayerSeekControl.js
@@ -29,7 +29,7 @@ export const PlayerSeekControl = () => {
   return (
     <div className="flex justify-center items-center">
       <Duration className="w-24 text-right" seconds={duration ? seekLocation * duration : 0} />
-      <input type="range" min={0} max={1} step={stepSize}
+      <input type="range" min={0} max={1} step={!isNaN(stepSize) ? stepSize : ''}
         className="mx-2 flex-shrink-0"
         value={seekLocation || 0}
         onMouseDown={() => setIsSeeking(true)}

--- a/src/components/player/PlayerSeekControl.test.js
+++ b/src/components/player/PlayerSeekControl.test.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { PlayerContext } from './PlayerProvider';
+import { PlayerSeekControl } from './PlayerSeekControl';
+
+let playerRef;
+
+const renderComponent = (ui, contextValues) => {
+  render(
+    <PlayerContext.Provider value={contextValues}>
+      {ui}
+    </PlayerContext.Provider>
+  );
+};
+
+describe('player seek control functionality', () => {
+  beforeEach(() => {
+    playerRef = {
+      current: {
+        seekTo: jest.fn()
+      }
+    }
+  });
+
+  test('if duration and elapsed are null, renders 0:00 as start time and -- as end time', () => {
+    const context = {
+      playerRef,
+      elapsed: null,
+      duration: null
+    };
+
+    renderComponent(<PlayerSeekControl />, context);
+
+    expect(screen.getByText('0:00')).toBeInTheDocument();
+    expect(screen.getByText('--')).toBeInTheDocument();
+  });
+
+  test('if duration and elapsed are set, renders proper start and end values', () => {
+    const context = {
+      playerRef,
+      elapsed: 0.2,
+      duration: 20
+    };
+
+    renderComponent(<PlayerSeekControl />, context);
+
+    expect(screen.getByText('0:04')).toBeInTheDocument();
+    expect(screen.getByText('0:20')).toBeInTheDocument();
+  });
+
+  test('changing the value in the range input updates start time displayed', () => {
+    const context = {
+      playerRef,
+      elapsed: 0.2,
+      duration: 20
+    };
+
+    renderComponent(<PlayerSeekControl />, context);
+
+    const seekControl = screen.getByRole('slider');
+    fireEvent.mouseDown(seekControl);
+    fireEvent.change(seekControl, { target: { value: '0.4' }});
+
+    expect(screen.getByText('0:08')).toBeInTheDocument();
+    expect(screen.getByText('0:20')).toBeInTheDocument();
+  });
+
+  test('changing the value in the range input does not call seekTo method of player until user releases mouse', () => {
+    const context = {
+      playerRef,
+      elapsed: 0.2,
+      duration: 20
+    };
+
+    renderComponent(<PlayerSeekControl />, context);
+
+    const seekControl = screen.getByRole('slider');
+    fireEvent.mouseDown(seekControl);
+    fireEvent.change(seekControl, { target: { value: '0.4' }});
+
+    expect(playerRef.current.seekTo).not.toHaveBeenCalled();
+  });
+
+  test('changing the value in the range input and then releasing the mouse does call the seekTo method of player with value selected', () => {
+    const context = {
+      playerRef,
+      elapsed: 0.2,
+      duration: 20
+    };
+
+    renderComponent(<PlayerSeekControl />, context);
+
+    const seekControl = screen.getByRole('slider');
+    fireEvent.mouseDown(seekControl);
+    fireEvent.change(seekControl, { target: { value: '0.4' }});
+    fireEvent.mouseUp(seekControl);
+
+    expect(playerRef.current.seekTo).toHaveBeenCalledTimes(1);
+    expect(playerRef.current.seekTo).toHaveBeenCalledWith(0.4, 'fraction');
+  });
+});

--- a/src/components/song/SongDetail.test.js
+++ b/src/components/song/SongDetail.test.js
@@ -7,14 +7,13 @@ import { createMemoryHistory } from 'history';
 import { SongDetail } from './SongDetail';
 import { PlayerContext } from '../player/PlayerProvider';
 
-const mockSetQueue = jest.fn();
-const mockPlay = jest.fn();
+const mockUpdateQueue = jest.fn();
 
 const renderComponent = ui => {
   const history = createMemoryHistory();
 
   render(
-    <PlayerContext.Provider value={{ setQueue: mockSetQueue, play: mockPlay }}>
+    <PlayerContext.Provider value={{ updateQueue: mockUpdateQueue }}>
       <Router history={history}>
         {ui}
       </Router>
@@ -80,8 +79,8 @@ describe('song detail view functionality', () => {
     renderComponent(<SongDetail song={song} />);
 
     userEvent.click(screen.getByRole('button'));
-    expect(mockSetQueue).toHaveBeenCalledTimes(1);
-    expect(mockSetQueue).toHaveBeenCalledWith([{
+    expect(mockUpdateQueue).toHaveBeenCalledTimes(1);
+    expect(mockUpdateQueue).toHaveBeenCalledWith([{
       id: 1,
       name: 'Famous',
       artist: {
@@ -98,15 +97,12 @@ describe('song detail view functionality', () => {
       ]
     }]);
 
-    expect(mockPlay).toHaveBeenCalledTimes(1);
-    expect(mockPlay).toHaveBeenCalledWith(0);
-
     const dropdown = screen.getByRole('combobox');
     userEvent.selectOptions(dropdown, 'https://soundcloud.com/themagneticfields/famous-1');
 
     userEvent.click(screen.getByRole('button'));
-    expect(mockSetQueue).toHaveBeenCalledTimes(2);
-    expect(mockSetQueue).toHaveBeenCalledWith([{
+    expect(mockUpdateQueue).toHaveBeenCalledTimes(2);
+    expect(mockUpdateQueue).toHaveBeenCalledWith([{
       id: 1,
       name: 'Famous',
       artist: {
@@ -122,7 +118,5 @@ describe('song detail view functionality', () => {
         { id: 1, genre: { id: 1, name: 'Indie Pop' } }
       ]
     }]);
-
-    expect(mockPlay).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,11 +1,13 @@
 import { convertCamelToSnake, convertSnakeToCamel, translateObjectKeys } from './caseConversions';
 import { request } from './request';
 import { queryParamsToString } from './queryParamsToString';
+import { convertSecondsToTimeString } from './timeFormatters';
 
 export {
   convertCamelToSnake,
   convertSnakeToCamel,
   translateObjectKeys,
   request,
-  queryParamsToString
+  queryParamsToString,
+  convertSecondsToTimeString
 };

--- a/src/utils/timeFormatters.js
+++ b/src/utils/timeFormatters.js
@@ -1,0 +1,15 @@
+/**
+ * Given an amount of seconds, convert into string in M:SS format. If provided seconds value is not numeric, will just return the provided value back.
+ * @param {any} seconds Amount of seconds to turn into M:SS formatted string. If isNaN, just returns seconds as passed in.
+ */
+export const convertSecondsToTimeString = seconds => {
+  if(isNaN(seconds)) return seconds;
+  seconds = parseInt(seconds);
+  if(!seconds) return '0:00';
+
+  const minutesPart = Math.floor(seconds / 60);
+  let secondsPart = seconds % 60;
+  if(secondsPart.toString().length === 1) secondsPart = '0' + secondsPart;
+
+  return `${minutesPart}:${secondsPart}`;
+};


### PR DESCRIPTION
This PR adds seeking functionality + control to the player, in addition to the player displaying what its elapsed moment in a song currently is and its full duration. Some of the player context api was refactored to better work with these new concepts of elapsed time / duration time, in particular handling how to reset them when songs change or when queues change. Tests are added for the seek control and the duration display component. 