### PR TITLE
disable seek control until user has started playing a song

### DIFF
--- a/src/components/player/Player.js
+++ b/src/components/player/Player.js
@@ -4,7 +4,7 @@ import ReactPlayer from 'react-player';
 import { PlayerContext } from './PlayerProvider';
 
 export const Player = () => {
-  const { setIsPlaying, isPlaying, currentSongUrl, skip, setDuration, setElapsed, setPlayerRef } = useContext(PlayerContext);
+  const { setIsPlaying, isPlaying, currentSongUrl, skip, setDuration, setElapsed, setPlayerRef, setCanSeek } = useContext(PlayerContext);
 
   const playerRef = useRef(null);
 
@@ -17,6 +17,7 @@ export const Player = () => {
   const handleProgress = progress => {
     if(isPlaying) {
       setElapsed(progress.played);
+      setCanSeek(true);
     }
   };
 

--- a/src/components/player/PlayerProvider.js
+++ b/src/components/player/PlayerProvider.js
@@ -22,6 +22,7 @@ export const PlayerProvider = props => {
   const [ queue, setQueue ] = useState([]);
   const [ playIndex, setPlayIndex ] = useState(0);
   const [ isPlaying, setIsPlaying ] = useState(null);
+  const [ canSeek, setCanSeek ] = useState(false);
   const [ duration, setDuration ] = useState(null);
   const [ elapsed, setElapsed ] = useState(null);
   const [ playerRef, setPlayerRef ] = useState(null);
@@ -52,6 +53,10 @@ export const PlayerProvider = props => {
       localStorage.setItem(`${user.id}_playerState`, JSON.stringify(toSerialize));
     }
   }, [ user, playIndex, queue ]);
+
+  useEffect(() => {
+    setCanSeek(false);
+  }, [ playIndex ]);
 
   const currentSong = queue[playIndex];
 
@@ -95,7 +100,7 @@ export const PlayerProvider = props => {
   return (
     <PlayerContext.Provider value={{
       queue, updateQueue, play, pause, skip, setIsPlaying, isPlaying, currentSong, currentSongUrl,
-      duration, setDuration, elapsed, setElapsed, playerRef, setPlayerRef
+      duration, setDuration, elapsed, setElapsed, playerRef, setPlayerRef, canSeek, setCanSeek
     }}>
       { props.children }
     </PlayerContext.Provider>

--- a/src/components/player/PlayerSeekControl.js
+++ b/src/components/player/PlayerSeekControl.js
@@ -5,7 +5,7 @@ import { Duration } from './Duration';
 
 export const PlayerSeekControl = () => {
   const [ isSeeking, setIsSeeking ] = useState(false);
-  const { elapsed, duration, playerRef } = useContext(PlayerContext);
+  const { elapsed, duration, playerRef, canSeek } = useContext(PlayerContext);
   const [ seekLocation, setSeekLocation ] = useState(elapsed);
 
   useEffect(() => {
@@ -31,6 +31,7 @@ export const PlayerSeekControl = () => {
       <Duration className="w-24 text-right" seconds={duration ? seekLocation * duration : 0} />
       <input type="range" min={0} max={1} step={!isNaN(stepSize) ? stepSize : ''}
         className="mx-2 flex-shrink-0"
+        disabled={!canSeek}
         value={seekLocation || 0}
         onMouseDown={() => setIsSeeking(true)}
         onChange={handleSeek}

--- a/src/components/player/PlayerSeekControl.test.js
+++ b/src/components/player/PlayerSeekControl.test.js
@@ -49,11 +49,26 @@ describe('player seek control functionality', () => {
     expect(screen.getByText('0:20')).toBeInTheDocument();
   });
 
+  test('slider is disabled if canSeek from context is false', () => {
+    const context = {
+      playerRef,
+      elapsed: 0.2,
+      duration: 20,
+      canSeek: false
+    };
+
+    renderComponent(<PlayerSeekControl />, context);
+
+    const seekControl = screen.getByRole('slider');
+    expect(seekControl).toBeDisabled();
+  });
+
   test('changing the value in the range input updates start time displayed', () => {
     const context = {
       playerRef,
       elapsed: 0.2,
-      duration: 20
+      duration: 20,
+      canSeek: true
     };
 
     renderComponent(<PlayerSeekControl />, context);
@@ -70,7 +85,8 @@ describe('player seek control functionality', () => {
     const context = {
       playerRef,
       elapsed: 0.2,
-      duration: 20
+      duration: 20,
+      canSeek: true
     };
 
     renderComponent(<PlayerSeekControl />, context);
@@ -86,7 +102,8 @@ describe('player seek control functionality', () => {
     const context = {
       playerRef,
       elapsed: 0.2,
-      duration: 20
+      duration: 20,
+      canSeek: true
     };
 
     renderComponent(<PlayerSeekControl />, context);


### PR DESCRIPTION
There was a bug in the SoundCloud player specifically where seeking to a specific point in the song before the song started being played would make the song never be able to be played. This fixes that by disabling the seek control until the user has started playing a song.