### PR TITLE
service is pulled from url instead of being manually chosen

### DIFF
--- a/src/components/player/Player.js
+++ b/src/components/player/Player.js
@@ -4,7 +4,7 @@ import ReactPlayer from 'react-player';
 import { PlayerContext } from './PlayerProvider';
 
 export const Player = () => {
-  const { setIsPlaying, isPlaying, currentSongUrl, skip, setDuration, setElapsed, setPlayerRef, setCanSeek } = useContext(PlayerContext);
+  const { isPlaying, currentSongUrl, skip, setDuration, setElapsed, setPlayerRef, setCanSeek } = useContext(PlayerContext);
 
   const playerRef = useRef(null);
 
@@ -26,8 +26,6 @@ export const Player = () => {
       <ReactPlayer width={0} height={0}
         ref={playerRef}
         onEnded={() => skip(1)}
-        onPause={() => setIsPlaying(false)}
-        onPlay={() => setIsPlaying(true)}
         onDuration={duration => setDuration(duration)}
         onProgress={handleProgress}
         url={currentSongUrl}

--- a/src/components/song/SongEditForm.test.js
+++ b/src/components/song/SongEditForm.test.js
@@ -56,7 +56,6 @@ describe('song edit form functionality', () => {
     expect(screen.getByText('Clear Artist')).toBeInTheDocument();
     expect(screen.getByLabelText('Year')).toEqual(screen.getByDisplayValue('1996'));
     expect(screen.getByText('Remove Indie Pop')).toBeInTheDocument();
-    expect(screen.getByLabelText('Service')).toEqual(screen.getByDisplayValue('YouTube'));
     expect(screen.getByLabelText('Song URL')).toEqual(screen.getByDisplayValue('https://www.youtube.com/watch?v=r1aLwEQc6LM'));
     expect(screen.getByLabelText('Is Primary?')).toBeChecked();
   });

--- a/src/components/song/SongForm.test.js
+++ b/src/components/song/SongForm.test.js
@@ -23,7 +23,6 @@ describe('song form validation', () => {
     expect(await screen.findByText('Artist is required.')).toBeInTheDocument();
     expect(await screen.findByText('Year must be a number.')).toBeInTheDocument();
     expect(await screen.findByText('You must select at least one genre.')).toBeInTheDocument();
-    expect(await screen.findByText('Service is required.')).toBeInTheDocument();
     expect(await screen.findByText('Song URL is required.')).toBeInTheDocument();
     expect(screen.getByLabelText('Is Primary?')).toBeChecked();
   });
@@ -126,11 +125,9 @@ describe('song form functionality', () => {
     expect(await screen.findByText('indie folk')).toBeInTheDocument();
     await waitFor(() => userEvent.click(screen.getByText('indie pop')));
 
-    await waitFor(() => userEvent.selectOptions(screen.getByLabelText('Service'), 'YouTube'));
     await waitFor(() => userEvent.type(screen.getByLabelText('Song URL'), 'https://www.youtube.com/watch?v=4rk_9cYOp8A'));
 
     await waitFor(() => userEvent.click(screen.getByText('Add Additional Source')));
-    await waitFor(() => userEvent.selectOptions(screen.getAllByLabelText('Service')[1], 'SoundCloud'));
     await waitFor(() => userEvent.type(screen.getAllByLabelText('Song URL')[1], 'https://soundcloud.com/themagneticfields/save-a-secret-for-the-moon-1'));
 
     await waitFor(() => userEvent.click(screen.getByText('Create Song')));
@@ -170,7 +167,6 @@ describe('song form functionality', () => {
     expect(screen.getByLabelText('Year')).toEqual(screen.getByDisplayValue('1973'));
     expect(screen.getByText('Remove Folk')).toBeInTheDocument();
     expect(screen.getByText('Remove Classic Rock')).toBeInTheDocument();
-    expect(screen.getByLabelText('Service')).toEqual(screen.getByDisplayValue('YouTube'));
     expect(screen.getByLabelText('Song URL')).toEqual(screen.getByDisplayValue('https://www.youtube.com/watch?v=EA2BNB_4m3g'));
     expect(screen.getByLabelText('Is Primary?')).toBeChecked();
 


### PR DESCRIPTION
This PR adds functionality to the song form that automatically identifies the service being chosen as a song source based on the URL and removes the Services dropdown from the form. It also adds Vimeo and Dailymotion as valid source choices. It also removes the onPlay and onPause handlers from the Player because they were causing some weird interactions with different player implementations oh well. 