### PR TITLE
Enhancement/redirect on unowned edit form

### DIFF
--- a/src/components/artist/ArtistEditForm.js
+++ b/src/components/artist/ArtistEditForm.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import { Redirect } from 'react-router-dom';
 
 import { api } from '../../api';
-import { useApi } from '../../hooks';
+import { useApi, useIsUser } from '../../hooks';
 import { LoadingIndicator, WarningText } from '../common';
 import { ArtistForm } from './ArtistForm';
 
@@ -9,10 +10,15 @@ export const ArtistEditForm = props => {
   const { artistId } = props;
 
   const [ artist, isLoading, error ] = useApi(api.artists.get, artistId);
+  const isUserCreatedArtist = useIsUser(artist?.creator?.id);
+
+  if(isUserCreatedArtist === false) {
+    return <Redirect to="/" />;
+  }
 
   return <>
     <LoadingIndicator isLoading={isLoading} />
     <WarningText>{error}</WarningText>
-    { artist && <ArtistForm artist={artist} /> }
+    { artist && isUserCreatedArtist && <ArtistForm artist={artist} /> }
   </>;
 };

--- a/src/components/artist/ArtistEditForm.test.js
+++ b/src/components/artist/ArtistEditForm.test.js
@@ -1,17 +1,35 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import { render, screen, waitFor } from '@testing-library/react';
 
 import { api } from '../../api';
 import { ArtistEditForm } from './ArtistEditForm';
+import { UserContext } from '../user/UserProvider';
 
 jest.mock('../../api');
 const mockGetArtist = (api.artists.get = jest.fn());
 
+const renderComponent = (ui, contextData) => {
+  const history = createMemoryHistory();
+  history.push('/artists/1/edit');
+
+  render(
+    <UserContext.Provider value={contextData}>
+      <Router history={history}>
+        {ui}
+      </Router>
+    </UserContext.Provider>
+  );
+
+  return history;
+};
+
 describe('artist edit form functionality', () => {
   test('fetches artist with id passed in props on load and renders edit form with artist data prepopulated', async () => {
-    mockGetArtist.mockResolvedValueOnce({ id: 1, name: 'of Montreal', foundedYear: 1996, description: 'The band.' });
+    mockGetArtist.mockResolvedValueOnce({ id: 1, name: 'of Montreal', foundedYear: 1996, description: 'The band.', creator: { id: 1 } });
 
-    render(<ArtistEditForm artistId={1} />);
+    renderComponent(<ArtistEditForm artistId={1} />, { user: { id: 1 } });
 
     expect(mockGetArtist).toHaveBeenCalledTimes(1);
     expect(mockGetArtist).toHaveBeenCalledWith(1);
@@ -23,10 +41,19 @@ describe('artist edit form functionality', () => {
     expect(screen.getByLabelText('Description')).toEqual(screen.getByDisplayValue('The band.'));
   });
 
+  test('redirects to / if user attempting to edit artist is not creator of artist', async () => {
+    mockGetArtist.mockResolvedValueOnce({ id: 1, name: 'of Montreal', foundedYear: 1996, description: 'The band.', creator: { id: 1 } });
+
+    const history = renderComponent(<ArtistEditForm artistId={1} />, { user: { id: 2 } });
+
+    expect(history.location.pathname).toEqual('/artists/1/edit');
+    await waitFor(() => expect(history.location.pathname).toEqual('/'));
+  });
+
   test('renders error message if artist load error occurred', async () => {
     mockGetArtist.mockRejectedValueOnce({ message: 'Artist load failed.' });
 
-    render(<ArtistEditForm artistId={1} />);
+    renderComponent(<ArtistEditForm artistId={1} />, { user: { id: 1 } });
 
     expect(await screen.findByText('Artist load failed.')).toBeInTheDocument();
     expect(screen.queryByRole('form')).not.toBeInTheDocument();

--- a/src/components/artist/ArtistPage.js
+++ b/src/components/artist/ArtistPage.js
@@ -1,8 +1,7 @@
-import React, { useState, useContext } from 'react';
+import React, { useState } from 'react';
 
 import { api } from '../../api';
-import { useApi, useDeleteAndRedirect, usePagination } from '../../hooks';
-import { UserContext } from '../user/UserProvider';
+import { useApi, useDeleteAndRedirect, usePagination, useIsUser } from '../../hooks';
 import { PlayButton } from '../player/PlayButton';
 import { SongList } from '../song/SongList';
 import { Page, LoadingIndicator, WarningText, ListSortOptions, PaginationControls, LinkButton, DeleteButton } from '../common';
@@ -10,14 +9,14 @@ import { Page, LoadingIndicator, WarningText, ListSortOptions, PaginationControl
 export const ArtistPage = props => {
   const { artistId } = props;
 
-  const { user } = useContext(UserContext);
-
   const [ orderBy, setOrderBy ] = useState({ orderBy: 'year', direction: 'desc' });
   const [ paginationParams, paginationFunctions ] = usePagination();
   const [ artist, isArtistLoading, artistError ] = useApi(api.artists.get, artistId);
   const [ songsResponse, isSongsLoading, songsError ] = useApi(api.songs.list, { artist: artistId, ...orderBy, ...paginationParams });
 
   const [ handleDelete, deleteError ] = useDeleteAndRedirect(api.artists.delete, artistId);
+
+  const isUserCreatedArtist = useIsUser(artist?.creator?.id);
 
   const songs = songsResponse?.data;
   const songsCount = songsResponse?.count;
@@ -36,7 +35,7 @@ export const ArtistPage = props => {
           <p className="text-xl my-2">Founded: {artist.foundedYear}</p>
           <p>{artist.description}</p>
         </div>
-        { user?.id === artist.creator.id && (
+        { isUserCreatedArtist && (
           <div className="flex">
             <LinkButton className="mr-2" to={`/artists/${artistId}/edit`}>edit</LinkButton>
             <DeleteButton onDelete={handleDelete} accessibleName="Delete Artist" />

--- a/src/components/list/ListEditForm.js
+++ b/src/components/list/ListEditForm.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import { Redirect } from 'react-router-dom';
 
 import { api } from '../../api';
-import { useApi } from '../../hooks';
+import { useApi, useIsUser } from '../../hooks';
 import { LoadingIndicator, WarningText } from '../common';
 import { ListForm } from './ListForm';
 
@@ -9,11 +10,16 @@ export const ListEditForm = props => {
   const { listId } = props;
 
   const [ list, isLoading, error ] = useApi(api.lists.get, listId);
+  const isUserCreatedList = useIsUser(list?.creator?.id);
+
+  if(isUserCreatedList === false) {
+    return <Redirect to="/" />;
+  }
 
   return <>
     <LoadingIndicator isLoading={isLoading} />
     <WarningText>{error}</WarningText>
-    { list && <ListForm list={{
+    { list && isUserCreatedList && <ListForm list={{
       id: list.id,
       name: list.name,
       description: list.description,

--- a/src/components/list/ListPage.js
+++ b/src/components/list/ListPage.js
@@ -1,8 +1,7 @@
-import React, { useContext } from 'react';
+import React from 'react';
 
 import { api } from '../../api';
-import { useApi, useDeleteAndRedirect } from '../../hooks';
-import { UserContext } from '../user/UserProvider';
+import { useApi, useDeleteAndRedirect, useIsUser } from '../../hooks';
 import { Page, LoadingIndicator, WarningText, LinkButton, DeleteButton } from '../common';
 import { ListDetail } from './ListDetail';
 import { ListSongList } from './ListSongList';
@@ -11,10 +10,10 @@ import { ListFavoriteControl } from './ListFavoriteControl';
 export const ListPage = props => {
   const { listId } = props;
 
-  const { user } = useContext(UserContext);
-
   const [ list, isLoading, error, refreshList ] = useApi(api.lists.get, listId);
   const [ handleDelete, deleteError ] = useDeleteAndRedirect(api.lists.delete, listId);
+
+  const isUserCreatedList = useIsUser(list?.creator?.id);
 
   const handleFavoriteClick = async () => {
     if(list.hasRaterFavorited) {
@@ -38,7 +37,7 @@ export const ListPage = props => {
             <ListDetail list={list} />
             <div className="flex">
               {
-                list.creator.id === user?.id && 
+                isUserCreatedList && 
                   <>
                     <LinkButton className="mr-2" to={`/lists/${listId}/edit`}>edit</LinkButton>
                     <DeleteButton className="mr-2" onDelete={handleDelete} accessibleName="Delete List" />

--- a/src/components/song/SongEditForm.js
+++ b/src/components/song/SongEditForm.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import { Redirect } from 'react-router-dom';
 
 import { api } from '../../api';
-import { useApi } from '../../hooks';
+import { useApi, useIsUser } from '../../hooks';
 import { LoadingIndicator, WarningText } from '../common';
 import { SongForm } from './SongForm';
 
@@ -9,11 +10,16 @@ export const SongEditForm = props => {
   const { songId } = props;
 
   const [ song, isLoading, error ] = useApi(api.songs.get, songId);
+  const isUserCreatedSong = useIsUser(song?.creator?.id);
+
+  if(isUserCreatedSong === false) {
+    return <Redirect to="/" />;
+  }
 
   return <>
     <LoadingIndicator isLoading={isLoading} />
     <WarningText>{error}</WarningText>
-    { song && <SongForm song={{
+    { song && isUserCreatedSong && <SongForm song={{
       id: song.id,
       name: song.name,
       artist: song.artist,

--- a/src/components/song/SongPage.js
+++ b/src/components/song/SongPage.js
@@ -1,7 +1,7 @@
 import React, { useState, useContext } from 'react';
 
 import { api } from '../../api';
-import { useApi, usePagination, useDeleteAndRedirect } from '../../hooks';
+import { useApi, usePagination, useDeleteAndRedirect, useIsUser } from '../../hooks';
 import { UserContext } from '../user/UserProvider';
 import { Page, LoadingIndicator, WarningText, ListSortOptions, PaginationControls } from '../common';
 import { SongDetail } from './SongDetail';
@@ -29,6 +29,8 @@ export const SongPage = props => {
   const [ song, isSongLoading, songError, refreshSong ] = useApi(api.songs.get, songId);
   const [ ratingsResponse, isRatingsLoading, ratingsError, refreshRatings ] = useApi(api.ratings.list, { songId, ...ratingSortOptions, ...ratingsPaginationParams });
   const [ listsResponse, isListsLoading, listsError ] = useApi(api.lists.list, { songId, ...listsPaginationParams });
+
+  const isUserCreatedSong = useIsUser(song?.creator?.id);
 
   const ratings = ratingsResponse?.data;
   const ratingsCount = ratingsResponse?.count;
@@ -82,7 +84,7 @@ export const SongPage = props => {
         <WarningText>{songError}</WarningText>
         <WarningText>{deleteError}</WarningText>
         <LoadingIndicator isLoading={!song && isSongLoading} />
-        { song && <SongDetail song={song} onDelete={handleDelete} canUserModify={user?.id === song.creator.id} /> }
+        { song && <SongDetail song={song} onDelete={handleDelete} canUserModify={isUserCreatedSong} /> }
         { ratings && (
           <div className="flex flex-col items-center md:items-start">
             <RatingControl value={userRating?.rating} onClick={rateSong} /> 

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -4,6 +4,7 @@ import { useDebounce } from './useDebounce';
 import { useClickOutside } from './useClickOutside';
 import { useClickInside } from './useClickInside';
 import { useDeleteAndRedirect } from './useDeleteAndRedirect';
+import { useIsUser } from './useIsUser';
 
 export {
   useApi,
@@ -11,5 +12,6 @@ export {
   useDebounce,
   useClickOutside,
   useClickInside,
-  useDeleteAndRedirect
+  useDeleteAndRedirect,
+  useIsUser
 };

--- a/src/hooks/useIsUser.js
+++ b/src/hooks/useIsUser.js
@@ -1,0 +1,17 @@
+import { useState, useContext, useEffect } from 'react';
+
+import { UserContext } from '../components/user/UserProvider';
+
+export const useIsUser = userId => {
+  const [ isUser, setIsUser ] = useState(false);
+
+  const { user } = useContext(UserContext);
+
+  useEffect(() => {
+    if(userId && user) {
+      setIsUser(user.id === userId);
+    }
+  }, [ user, userId ]);
+
+  return isUser;
+};

--- a/src/hooks/useIsUser.js
+++ b/src/hooks/useIsUser.js
@@ -3,7 +3,7 @@ import { useState, useContext, useEffect } from 'react';
 import { UserContext } from '../components/user/UserProvider';
 
 export const useIsUser = userId => {
-  const [ isUser, setIsUser ] = useState(false);
+  const [ isUser, setIsUser ] = useState(null);
 
   const { user } = useContext(UserContext);
 


### PR DESCRIPTION
This PR adds logic to redirect to `/` if user attempting to edit some resource did not create that resource. It also adds a new `useIsUser` hook that checks if a given id matches the id of the logged-in user, and I used this in all ownership tests instead of directly using context.