### PR TITLE
update skip implementation to handle skips for single song queues

### DIFF
--- a/src/components/player/PlayerProvider.js
+++ b/src/components/player/PlayerProvider.js
@@ -72,11 +72,9 @@ export const PlayerProvider = props => {
   };
 
   const skip = increment => {
-    updatePlayIndex(prevPlayIndex => {
-      let nextIndex = prevPlayIndex + increment;
-      if(nextIndex < 0) nextIndex = queue.length - 1;
-      return nextIndex % queue.length;
-    });
+    let nextIndex = playIndex + increment;
+    if(nextIndex < 0) nextIndex = queue.length - 1;
+    updatePlayIndex(nextIndex % queue.length);
   };
 
   const updatePlayIndex = idx => {


### PR DESCRIPTION
This reimplements song skipping logic to handle single-song queues which previously did not handle `skip` calls very well.