### PR TITLE
Handle playback error

### DIFF
--- a/src/components/player/Player.js
+++ b/src/components/player/Player.js
@@ -4,7 +4,7 @@ import ReactPlayer from 'react-player';
 import { PlayerContext } from './PlayerProvider';
 
 export const Player = () => {
-  const { isPlaying, currentSongUrl, skip, duration, setDuration, setElapsed, setPlayerRef, setCanSeek } = useContext(PlayerContext);
+  const { isPlaying, currentSongUrl, skip, duration, handlePlaybackError, setDuration, setElapsed, setPlayerRef, setCanSeek } = useContext(PlayerContext);
 
   const playerRef = useRef(null);
 
@@ -30,6 +30,7 @@ export const Player = () => {
         ref={playerRef}
         onEnded={() => skip(1)}
         onDuration={duration => setDuration(duration)}
+        onError={handlePlaybackError}
         onProgress={handleProgress}
         url={currentSongUrl}
         playing={isPlaying} />

--- a/src/components/player/PlayerContainer.js
+++ b/src/components/player/PlayerContainer.js
@@ -80,7 +80,7 @@ export const PlayerContainer = () => {
         </> }
     </div>
 
-    <div className="fixed top-0 right-0 p-8 z-50">
+    <div className="fixed top-0 right-0 p-8 z-50 w-1/4 flex justify-end">
       <PlayerErrorLog />
     </div>
   </>;

--- a/src/components/player/PlayerContainer.js
+++ b/src/components/player/PlayerContainer.js
@@ -3,6 +3,7 @@ import { MdExpandLess, MdQueueMusic } from 'react-icons/md';
 
 import { PlayerControls } from './PlayerControls';
 import { PlayerContext } from './PlayerProvider';
+import { PlayerErrorLog } from './PlayerErrorLog';
 import { Player } from './Player';
 import { Queue } from './Queue';
 import { RemoveButton } from '../common';
@@ -77,6 +78,10 @@ export const PlayerContainer = () => {
           <RemoveButton className="ml-auto" accessibleName="Hide Queue" onClick={() => setIsQueueShowing(false)} />
           <Queue />
         </> }
+    </div>
+
+    <div className="fixed top-0 right-0 p-8 z-50">
+      <PlayerErrorLog />
     </div>
   </>;
 };

--- a/src/components/player/PlayerContainer.test.js
+++ b/src/components/player/PlayerContainer.test.js
@@ -9,7 +9,8 @@ const mockSetPlayerRef = jest.fn();
 
 const renderComponent = (ui, isPlaying = false) => {
   return render(
-    <PlayerContext.Provider value={{ isPlaying, setPlayerRef: mockSetPlayerRef }}>
+    <PlayerContext.Provider value={{ isPlaying, setPlayerRef: mockSetPlayerRef,
+    errorQueue: [] }}>
       {ui}
     </PlayerContext.Provider>
   );

--- a/src/components/player/PlayerErrorLog.js
+++ b/src/components/player/PlayerErrorLog.js
@@ -10,12 +10,12 @@ export const PlayerErrorLog = () => {
   return (
     <ul className="flex flex-col items-end">
       {
-        errorQueue.map((e, idx) => (
-          <li key={e} className="p-4 my-4 rounded bg-black hover:bg-gray-800 hover:bg-opacity-80 bg-opacity-80 text-white relative">
+        errorQueue.map((errorMessage, idx) => (
+          <li key={errorMessage} className="p-4 my-4 rounded bg-black hover:bg-gray-800 hover:bg-opacity-80 bg-opacity-80 text-white relative">
             <button className="absolute top-0 left-0 w-full h-full" onClick={() => removeErrorMessage(idx)}>
               <span className="sr-only">Remove Error Message</span>
             </button>
-            {e}
+            {errorMessage}
           </li>
         ))
       }

--- a/src/components/player/PlayerErrorLog.js
+++ b/src/components/player/PlayerErrorLog.js
@@ -3,15 +3,20 @@ import React, { useContext } from 'react';
 import { PlayerContext } from './PlayerProvider';
 
 export const PlayerErrorLog = () => {
-  const { errorQueue } = useContext(PlayerContext);
+  const { errorQueue, removeErrorMessage } = useContext(PlayerContext);
 
   if(!errorQueue.length) return null;
 
   return (
     <ul className="flex flex-col items-end">
       {
-        errorQueue.map(e => (
-          <li key={e} className="p-4 my-4 rounded bg-black bg-opacity-80 text-white w-1/4">{e}</li>
+        errorQueue.map((e, idx) => (
+          <li key={e} className="p-4 my-4 rounded bg-black hover:bg-gray-800 hover:bg-opacity-80 bg-opacity-80 text-white relative">
+            <button className="absolute top-0 left-0 w-full h-full" onClick={() => removeErrorMessage(idx)}>
+              <span className="sr-only">Remove Error Message</span>
+            </button>
+            {e}
+          </li>
         ))
       }
     </ul>

--- a/src/components/player/PlayerErrorLog.js
+++ b/src/components/player/PlayerErrorLog.js
@@ -1,0 +1,19 @@
+import React, { useContext } from 'react';
+
+import { PlayerContext } from './PlayerProvider';
+
+export const PlayerErrorLog = () => {
+  const { errorQueue } = useContext(PlayerContext);
+
+  if(!errorQueue.length) return null;
+
+  return (
+    <ul className="flex flex-col items-end">
+      {
+        errorQueue.map(e => (
+          <li key={e} className="p-4 my-4 rounded bg-black bg-opacity-80 text-white w-1/4">{e}</li>
+        ))
+      }
+    </ul>
+  );
+};

--- a/src/components/player/PlayerErrorLog.test.js
+++ b/src/components/player/PlayerErrorLog.test.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { PlayerErrorLog } from './PlayerErrorLog';
+import { PlayerContext } from './PlayerProvider';
+
+const renderComponent = (ui, contextValues) => {
+  return render(
+    <PlayerContext.Provider value={contextValues}>
+      {ui}
+    </PlayerContext.Provider>
+  );
+};
+
+describe('player error log functionality', () => {
+  test('renders list of error messages from context if error messages exist', () => {
+    renderComponent(<PlayerErrorLog />, { errorQueue: [ 'Computer Error' ]});
+
+    expect(screen.getByRole('list')).toBeInTheDocument();
+
+    const listItem = screen.getByRole('listitem');
+    expect(listItem).toBeInTheDocument();
+    expect(listItem).toHaveTextContent('Computer Error');
+  });
+
+  test('renders nothing if no error messages exist', () => {
+    const { container } = renderComponent(<PlayerErrorLog />, { errorQueue: [] });
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('calls removeErrorMessage on click of error message', () => {
+    const mockRemoveErrorMessage = jest.fn();
+    
+    renderComponent(<PlayerErrorLog />, { errorQueue: ['Message 1', 'Message 2'], removeErrorMessage: mockRemoveErrorMessage });
+
+    const removeButtons = screen.getAllByRole('button');
+    expect(removeButtons).toHaveLength(2);
+
+    userEvent.click(removeButtons[0]);
+
+    expect(mockRemoveErrorMessage).toHaveBeenCalledTimes(1);
+    expect(mockRemoveErrorMessage).toHaveBeenCalledWith(0);
+  });
+});

--- a/src/components/player/PlayerProvider.js
+++ b/src/components/player/PlayerProvider.js
@@ -95,10 +95,29 @@ export const PlayerProvider = props => {
     setIsPlaying(true);
   };
 
+  // handle an error during playback - try to play a different source than the one that errored if available,
+  // otherwise skip to the next song in queue if more than one song in queue, or just stop playing the single song
+  const handlePlaybackError = () => {
+    if(currentSong.sources.length > 1) {
+      const errorUrl = currentSongUrl;
+      const updatedQueue = [ ...queue ];
+      const updatedSong = { ...currentSong };
+      updatedSong.sources = updatedSong.sources.filter(source => source.url !== errorUrl);
+      updatedQueue[playIndex] = updatedSong;
+      setQueue(updatedQueue);
+    }
+    else if(queue.length > 1) {
+      skip(1);
+    }
+    else {
+      setIsPlaying(false);
+    }
+  };
+
   return (
     <PlayerContext.Provider value={{
       queue, updateQueue, play, pause, skip, setIsPlaying, isPlaying, currentSong, currentSongUrl,
-      duration, setDuration, elapsed, setElapsed, playerRef, setPlayerRef, canSeek, setCanSeek
+      duration, setDuration, elapsed, setElapsed, playerRef, setPlayerRef, canSeek, setCanSeek, handlePlaybackError
     }}>
       { props.children }
     </PlayerContext.Provider>

--- a/src/components/player/PlayerProvider.js
+++ b/src/components/player/PlayerProvider.js
@@ -113,7 +113,7 @@ export const PlayerProvider = props => {
       setQueue(updatedQueue);
     }
     else {
-      addToErrorQueue(`A playable source was not found for ${currentSong.name} - removing song from queue.`);
+      addToErrorQueue(`The source attempted to play for ${currentSong.name} was not playable - removing song from queue.`);
       const updatedQueue = queue.filter(song => song.id !== currentSong.id);
       setQueue(updatedQueue);
     }
@@ -124,9 +124,15 @@ export const PlayerProvider = props => {
     setErrorQueue(updatedErrorQueue);
   };
 
+  const removeErrorMessage = idx => {
+    const updatedErrorQueue = [ ...errorQueue ];
+    updatedErrorQueue.splice(idx, 1);
+    setErrorQueue(updatedErrorQueue);
+  };
+
   return (
     <PlayerContext.Provider value={{
-      queue, updateQueue, play, pause, skip, setIsPlaying, isPlaying, currentSong, currentSongUrl, errorQueue, 
+      queue, updateQueue, play, pause, skip, setIsPlaying, isPlaying, currentSong, currentSongUrl, errorQueue, removeErrorMessage, 
       duration, setDuration, elapsed, setElapsed, playerRef, setPlayerRef, canSeek, setCanSeek, handlePlaybackError
     }}>
       { props.children }


### PR DESCRIPTION
Added error handling and error message displaying to handle and attempt to resolve playback errors in the Player. Now if a song errors during attempted playback: 

1. Another source will be chosen for the song if the song has multiple sources (repeat this step if error happens again).
2. The song will be removed from the queue if all sources for the song error out.

