### PR TITLE
set search term to empty string if removeOnSelect in AutocompleteSearchBar

### DIFF
--- a/src/components/common/AutocompleteSearchBar.js
+++ b/src/components/common/AutocompleteSearchBar.js
@@ -41,6 +41,7 @@ export const AutocompleteSearchBar = props => {
     if(removeOnSelect) {
       setSearchBarKey(prevSearchBarKey => prevSearchBarKey + 1);
       setResults([]);
+      setSearchTerm('');
     }
   };
 


### PR DESCRIPTION
Fixes a bug where if you searched something, selected a search result, then attempted to search the same thing, no results would be shown to you.